### PR TITLE
Update chat file upload

### DIFF
--- a/api/Avancira.Application/Catalog/Chats/ChatService.cs
+++ b/api/Avancira.Application/Catalog/Chats/ChatService.cs
@@ -1,6 +1,8 @@
 using Avancira.Application.Catalog.Dtos;
 using Avancira.Application.Identity.Users.Abstractions;
 using Avancira.Application.Persistence;
+using Avancira.Application.Storage;
+using Avancira.Application.Storage.File;
 using Avancira.Domain.Catalog.Enums;
 using Avancira.Domain.Messaging;
 using Microsoft.Extensions.Logging;
@@ -11,18 +13,18 @@ public class ChatService : IChatService
 {
     private readonly IRepository<Chat> _chatRepository;
     private readonly IUserService _userService;
-    private readonly IFileUploadService _fileUploadService;
+    private readonly IStorageService _storageService;
     private readonly ILogger<ChatService> _logger;
 
     public ChatService(
         IRepository<Chat> chatRepository,
         IUserService userService,
-        IFileUploadService fileUploadService,
+        IStorageService storageService,
         ILogger<ChatService> logger)
     {
         _chatRepository = chatRepository;
         _userService = userService;
-        _fileUploadService = fileUploadService;
+        _storageService = storageService;
         _logger = logger;
     }
 
@@ -106,7 +108,8 @@ public class ChatService : IChatService
         string? filePath = null;
         if (messageDto.File != null)
         {
-            filePath = await _fileUploadService.SaveFileAsync(messageDto.File, "chat");
+            var uri = await _storageService.UploadAsync<Chat>(messageDto.File, FileType.Image);
+            filePath = uri?.ToString();
         }
 
         chat.AddMessage(senderId, messageDto.RecipientId ?? string.Empty, messageDto.Content ?? string.Empty, filePath);

--- a/api/Avancira.Application/Catalog/Dtos/SendMessageDto.cs
+++ b/api/Avancira.Application/Catalog/Dtos/SendMessageDto.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
+using Avancira.Application.Storage.File.Dtos;
 
 namespace Avancira.Application.Catalog.Dtos
 {
@@ -12,7 +12,7 @@ namespace Avancira.Application.Catalog.Dtos
         public Guid ListingId { get; set; }
         public string? RecipientId { get; set; }
         public string? Content { get; set; }
-        public IFormFile? File { get; set; }
+        public FileUploadDto? File { get; set; }
 
         public SendMessageDto()
         {

--- a/api/Avancira.Application/Catalog/IFileUploadService.cs
+++ b/api/Avancira.Application/Catalog/IFileUploadService.cs
@@ -1,12 +1,12 @@
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
+using Avancira.Application.Storage.File.Dtos;
 
 public interface IFileUploadService
 {
     // Create
-    Task<string> SaveFileAsync(IFormFile file, string subDirectory = "");
+    Task<string> SaveFileAsync(FileUploadDto file, string subDirectory = "");
     // Update
-    Task<string?> ReplaceFileAsync(IFormFile? newFile, string? currentFilePath, string subDirectory = "");
+    Task<string?> ReplaceFileAsync(FileUploadDto? newFile, string? currentFilePath, string subDirectory = "");
     // Delete
     Task DeleteFileAsync(string filePath);
 }


### PR DESCRIPTION
## Summary
- use `FileUploadDto` instead of `IFormFile` for chat message uploads
- switch `ChatService` to use `IStorageService`
- update `IFileUploadService` and its implementation to support `FileUploadDto`

## Testing
- `dotnet build Avancira.sln -warnaserror` *(fails: `dotnet` not installed)*