### PR TITLE
Add refresh token handling for Angular client

### DIFF
--- a/Frontend.Angular/src/app/models/token-response.ts
+++ b/Frontend.Angular/src/app/models/token-response.ts
@@ -1,0 +1,5 @@
+export interface TokenResponse {
+  token: string;
+  refreshToken: string;
+  refreshTokenExpiryTime: string;
+}

--- a/Frontend.Angular/src/app/models/user-role-detail.ts
+++ b/Frontend.Angular/src/app/models/user-role-detail.ts
@@ -1,0 +1,6 @@
+export interface UserRoleDetail {
+  roleId: string;
+  roleName: string;
+  description: string;
+  enabled: boolean;
+}

--- a/Frontend.Angular/src/app/pages/signin/signin.component.ts
+++ b/Frontend.Angular/src/app/pages/signin/signin.component.ts
@@ -92,16 +92,8 @@ export class SigninComponent {
 
     this.spinner.show();
     this.authService.login(this.loginForm.value.email, this.loginForm.value.password).subscribe({
-      next: (result) => {
-        if (result) {
-          this.authService.saveToken(result.token);
-          this.authService.saveRoles(result.roles);
-          this.authService.saveEmail(this.loginForm.value.email);
-          // Redirect to returnUrl or dashboard
-          this.router.navigateByUrl(this.returnUrl);
-        } else {
-          this.toastr.error('Invalid email or password.', 'Error');
-        }
+      next: () => {
+        this.router.navigateByUrl(this.returnUrl);
         this.spinner.hide();
       },
       error: (error) => {

--- a/Frontend.Angular/src/app/pages/signup/signup.component.ts
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.ts
@@ -114,16 +114,8 @@ export class SignupComponent implements OnInit {
   // Handle user login after successful signup
   loginUser(): void {
     this.authService.login(this.signupForm.value.email, this.signupForm.value.password).subscribe({
-      next: (loginResult) => {
-        if (loginResult) {
-          this.authService.saveToken(loginResult.token);
-          this.authService.saveRoles(loginResult.roles);
-          this.authService.saveEmail(this.signupForm.value.email);
-
-          this.router.navigate(['/complete-registration']);
-        } else {
-          this.signupError = 'Signup succeeded, but automatic login failed.';
-        }
+      next: () => {
+        this.router.navigate(['/complete-registration']);
       },
       error: () => {
         this.signupError = 'Signup succeeded, but automatic login failed.';

--- a/Frontend.Angular/src/app/services/user.service.ts
+++ b/Frontend.Angular/src/app/services/user.service.ts
@@ -6,6 +6,7 @@ import { environment } from '../environments/environment';
 import { UserDiplomaStatus } from '../models/enums/user-diploma-status';
 import { UserPaymentSchedule } from '../models/enums/user-payment-schedule';
 import { User } from '../models/user';
+import { UserRoleDetail } from '../models/user-role-detail';
 
 @Injectable({
   providedIn: 'root',
@@ -62,6 +63,10 @@ export class UserService {
   
   getUserByToken(recommendationToken: string): Observable<User> {
     return this.http.get<User>(`${this.apiUrl}/by-token/${recommendationToken}`);
+  }
+
+  getUserRoles(userId: string): Observable<UserRoleDetail[]> {
+    return this.http.get<UserRoleDetail[]>(`${this.apiUrl}/${userId}/roles`);
   }
 
   getDiplomaStatus(): Observable<{ status: UserDiplomaStatus }> {


### PR DESCRIPTION
## Summary
- implement TokenResponse interface
- enhance `AuthService` with refresh token methods and login via `/auth/token`
- modify sign-in and sign-up to use new token endpoint
- refresh tokens automatically in `httpInterceptorFn`
- fetch user roles after login using `/users/{id}/roles`

## Testing
- `npm run build` *(fails: ng not found)*
- `dotnet test` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b5113e01c8328a1935a12f23abe3f