### PR TITLE
Improve client-side auth handling

### DIFF
--- a/Frontend.Angular/src/app/components/message-list/message-list.component.ts
+++ b/Frontend.Angular/src/app/components/message-list/message-list.component.ts
@@ -42,7 +42,7 @@ export class MessageListComponent implements OnInit {
   }
 
   isLoggedIn(): boolean {
-    return !!this.authService.getToken();
+    return this.authService.isLoggedIn();
   }
 
   logout() {

--- a/Frontend.Angular/src/app/components/payment-alt-options/payment-alt-options.component.ts
+++ b/Frontend.Angular/src/app/components/payment-alt-options/payment-alt-options.component.ts
@@ -6,6 +6,7 @@ import { ConfigService } from '../../services/config.service';
 import { ListingService } from '../../services/listing.service';
 import { PaymentService } from '../../services/payment.service';
 import { SubscriptionService } from '../../services/subscription.service';
+import { AuthService } from '../../services/auth.service';
 
 
 
@@ -36,12 +37,13 @@ export class PaymentAltOptionsComponent implements OnInit {
     private listingService: ListingService,
     private paymentService: PaymentService,
     private subscriptionService: SubscriptionService,
-    private configService: ConfigService
+    private configService: ConfigService,
+    private authService: AuthService
   ) { }
 
 
   ngOnInit(): void {
-    this.isLoggedIn = !!localStorage.getItem('token'); // Check if token exists
+    this.isLoggedIn = this.authService.isLoggedIn();
     this.stripePromise = loadStripe(this.configService.get('stripePublishableKey'));
 
     this.paymentService.loadPayPalScript().then(() => {

--- a/Frontend.Angular/src/app/guards/auth.guard.ts
+++ b/Frontend.Angular/src/app/guards/auth.guard.ts
@@ -1,16 +1,18 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
+import { AuthService } from '../services/auth.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AuthGuard implements CanActivate {
   constructor(
-    private router: Router
+    private router: Router,
+    private authService: AuthService
   ) {}
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-    const isAuthenticated = !!localStorage.getItem('token');
+    const isAuthenticated = this.authService.isLoggedIn();
 
     if (!isAuthenticated) {
       this.router.navigate(['/signin'], { queryParams: { returnUrl: state.url } });

--- a/Frontend.Angular/src/app/guards/role.guard.ts
+++ b/Frontend.Angular/src/app/guards/role.guard.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RoleGuard implements CanActivate {
+  constructor(private authService: AuthService, private router: Router) {}
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
+    const requiredRoles = route.data['roles'] as string[] | undefined;
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const hasRole = requiredRoles.some(role => this.authService.hasRole(role));
+    if (!hasRole) {
+      this.router.navigate(['/']);
+      return false;
+    }
+    return true;
+  }
+}

--- a/Frontend.Angular/src/app/interceptors/httpInterceptorFn.ts
+++ b/Frontend.Angular/src/app/interceptors/httpInterceptorFn.ts
@@ -15,7 +15,7 @@ export const httpInterceptorFn: HttpInterceptorFn = (
   const authService = inject(AuthService);
   
   // Add the Authorization header if the token exists
-  const token = localStorage.getItem('token');
+  const token = authService.getToken();
   if (token) {
     req = req.clone({
       setHeaders: {

--- a/Frontend.Angular/src/app/layout/shared/header/header.component.ts
+++ b/Frontend.Angular/src/app/layout/shared/header/header.component.ts
@@ -60,7 +60,7 @@ export class HeaderComponent {
   }
 
   isLoggedIn(): boolean {
-    return !!this.authService.getToken();
+    return this.authService.isLoggedIn();
   }
 
   logout() {

--- a/Frontend.Angular/src/app/pages/payment/payment.component.ts
+++ b/Frontend.Angular/src/app/pages/payment/payment.component.ts
@@ -7,6 +7,7 @@ import { PaymentMethodComponent } from "../../components/payment-method/payment-
 
 import { AlertService } from '../../services/alert.service';
 import { SubscriptionService } from '../../services/subscription.service';
+import { AuthService } from '../../services/auth.service';
 
 import { Card } from '../../models/card';
 import { TransactionPaymentMethod } from '../../models/enums/transaction-payment-method';
@@ -30,13 +31,14 @@ export class PaymentComponent implements OnInit {
     private alertService: AlertService,
     private route: ActivatedRoute,
     private router: Router,
-    private subscriptionService: SubscriptionService
+    private subscriptionService: SubscriptionService,
+    private authService: AuthService
   ) {
     this.handlePayment = this.handlePayment.bind(this);
   }
 
   ngOnInit(): void {
-    this.isLoggedIn = !!localStorage.getItem('token');
+    this.isLoggedIn = this.authService.isLoggedIn();
 
     this.route.queryParams.subscribe((params) => {
       this.referrer = params['referrer'] || '/';

--- a/Frontend.Angular/src/app/pages/premium-subscription/premium-subscription.component.ts
+++ b/Frontend.Angular/src/app/pages/premium-subscription/premium-subscription.component.ts
@@ -10,6 +10,7 @@ import { AlertService } from '../../services/alert.service';
 import { ConfigService } from '../../services/config.service';
 import { PaymentService } from '../../services/payment.service';
 import { SubscriptionService } from '../../services/subscription.service';
+import { AuthService } from '../../services/auth.service';
 
 import { Card } from '../../models/card';
 import { TransactionPaymentType } from '../../models/enums/transaction-payment-type';
@@ -47,11 +48,12 @@ export class PremiumSubscriptionComponent implements OnInit {
     private router: Router,
     private paymentService: PaymentService,
     private subscriptionService: SubscriptionService,
-    private configService: ConfigService
+    private configService: ConfigService,
+    private authService: AuthService
   ) {}
 
   ngOnInit(): void {
-    this.isLoggedIn = !!localStorage.getItem('token');
+    this.isLoggedIn = this.authService.isLoggedIn();
     this.stripePromise = loadStripe(this.configService.get('stripePublishableKey'));
   }
 


### PR DESCRIPTION
## Summary
- manage auth token through a `BehaviorSubject`
- refresh login checks throughout the UI
- refactor auth guard to use `AuthService`
- add a new `RoleGuard` for role-based routes
- simplify HTTP interceptor token lookup

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b59504cb08328bfac02ea9e19dd1c