### PR TITLE
Fix Google auth initialization

### DIFF
--- a/Frontend.Angular/src/app/services/google-auth.service.ts
+++ b/Frontend.Angular/src/app/services/google-auth.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { loadGapiInsideDOM } from 'gapi-script';
+
+// gapi is loaded dynamically by gapi-script
+declare const gapi: any;
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GoogleAuthService {
+  private initialized = false;
+
+  async init(clientId: string): Promise<void> {
+    if (this.initialized) return;
+
+    await loadGapiInsideDOM();
+
+    return new Promise((resolve, reject) => {
+      gapi.load('auth2', () => {
+        try {
+          gapi.auth2.init({
+            client_id: clientId,
+            scope: 'profile email'
+          });
+          this.initialized = true;
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+  }
+
+  getAuthInstance(): any | null {
+    if (!this.initialized) {
+      return null;
+    }
+    return gapi.auth2.getAuthInstance();
+  }
+}


### PR DESCRIPTION
## Summary
- create `GoogleAuthService` to manage gapi initialization
- use the service in signin and signup components

## Testing
- `npm test` *(fails: ng not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b5b0d10d48328a3cbc5538da43a7e