### PR TITLE
Improve login and signup components

### DIFF
--- a/Frontend.Angular/src/app/pages/signin/signin.component.html
+++ b/Frontend.Angular/src/app/pages/signin/signin.component.html
@@ -28,7 +28,7 @@
             <div class="form-group">
               <label class="form-control-label">Password</label>
               <div class="pass-group">
-                <input type="password" id="Input_Password" class="form-control" placeholder="Password"
+                <input [type]="showPassword ? 'text' : 'password'" id="Input_Password" class="form-control" placeholder="Password"
                   formControlName="password"
                   [ngClass]="{ 'is-invalid': loginForm.get('password')?.invalid && (loginForm.get('password')?.touched || loginForm.get('password')?.dirty) }"
                   autocomplete="current-password" />
@@ -36,12 +36,13 @@
                   *ngIf="loginForm.get('password')?.errors?.['required'] && (loginForm.get('password')?.touched || loginForm.get('password')?.dirty)">
                   Password is required.
                 </span>
-                <span class="fas fa-eye toggle-password"></span>
+                <span class="fas fa-eye toggle-password" (click)="togglePasswordVisibility()"></span>
               </div>
             </div>
             <div class="text-end">
               <a class="forgot-link" (click)="resetPassword()">Forgot Password ?</a>
             </div>
+            <div *ngIf="errorMessage" class="alert alert-danger">{{ errorMessage }}</div>
             <button class="btn btn-primary login-btn" type="submit" [disabled]="loginForm.invalid">Login</button>
             <div class="login-or">
               <span class="or-line"></span>

--- a/Frontend.Angular/src/app/pages/signup/signup.component.html
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.html
@@ -35,19 +35,25 @@
             </div>
             <div class="row">
               <div class="col-lg-6">
-                <div class="form-group">
+              <div class="form-group">
                   <label class="form-control-label">Password</label>
-                  <input type="password" id="Input_Password" class="form-control" placeholder="Password"
-                    formControlName="password" autocomplete="new-password"
-                    [ngClass]="{ 'is-invalid': signupForm.get('password')?.touched && signupForm.get('password')?.errors }" />
+                  <div class="pass-group">
+                    <input [type]="showPassword ? 'text' : 'password'" id="Input_Password" class="form-control" placeholder="Password"
+                      formControlName="password" autocomplete="new-password"
+                      [ngClass]="{ 'is-invalid': signupForm.get('password')?.touched && signupForm.get('password')?.errors }" />
+                    <span class="fas fa-eye toggle-password" (click)="togglePasswordVisibility('password')"></span>
+                  </div>
                 </div>
               </div>
               <div class="col-lg-6">
                 <div class="form-group">
                   <label class="form-control-label">Confirm Password</label>
-                  <input type="password" id="Input_VerifyPassword" class="form-control" placeholder="Verify password"
-                    formControlName="verifyPassword" autocomplete="new-password"
-                    [ngClass]="{ 'is-invalid': signupForm.get('verifyPassword')?.touched && signupForm.get('verifyPassword')?.errors }" />
+                  <div class="pass-group">
+                    <input [type]="showVerifyPassword ? 'text' : 'password'" id="Input_VerifyPassword" class="form-control" placeholder="Verify password"
+                      formControlName="verifyPassword" autocomplete="new-password"
+                      [ngClass]="{ 'is-invalid': signupForm.get('verifyPassword')?.touched && signupForm.get('verifyPassword')?.errors }" />
+                    <span class="fas fa-eye toggle-password" (click)="togglePasswordVisibility('verifyPassword')"></span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/Frontend.Angular/src/app/services/social-auth.service.ts
+++ b/Frontend.Angular/src/app/services/social-auth.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@angular/core';
+import { FacebookService, InitParams, LoginResponse } from 'ngx-facebook';
+import { firstValueFrom } from 'rxjs';
+
+import { GoogleAuthService } from './google-auth.service';
+import { ConfigService } from './config.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SocialAuthService {
+  private initialized = false;
+
+  constructor(
+    private fb: FacebookService,
+    private googleAuthService: GoogleAuthService,
+    private configService: ConfigService
+  ) {}
+
+  /** Initialize Facebook and Google SDKs using values from ConfigService */
+  init(): void {
+    if (this.initialized) {
+      return;
+    }
+
+    this.configService.loadConfig().subscribe({
+      next: async () => {
+        const initParams: InitParams = {
+          appId: this.configService.get('facebookAppId'),
+          cookie: true,
+          xfbml: true,
+          version: 'v21.0',
+        };
+        this.fb.init(initParams);
+
+        await this.googleAuthService.init(this.configService.get('googleClientId'));
+        this.initialized = true;
+      },
+      error: err => {
+        console.error('Failed to load configuration:', err.message);
+      },
+    });
+  }
+
+  /** Trigger Facebook login and return the OAuth token */
+  loginWithFacebook(): Promise<string> {
+    return this.fb
+      .login({ scope: 'email,public_profile' })
+      .then((response: LoginResponse) => response.authResponse.accessToken);
+  }
+
+  /** Trigger Google login and return the OAuth token */
+  async loginWithGoogle(): Promise<string> {
+    await this.googleAuthService.init(this.configService.get('googleClientId'));
+    const auth2 = this.googleAuthService.getAuthInstance();
+    if (!auth2) {
+      throw new Error('Google Auth instance not initialized');
+    }
+
+    const googleUser = await auth2.signIn();
+    return googleUser.getAuthResponse().id_token;
+  }
+}


### PR DESCRIPTION
## Summary
- add `SocialAuthService` to centralize Facebook and Google setup
- use the new service in login and signup flows
- add password visibility toggles and better error handling
- show spinners using `finalize` for cleaner code

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b5c3e27b88328a6b2ae216cd08984