### PR TITLE
Fix profile image upload

### DIFF
--- a/Frontend.Angular/src/app/models/user.ts
+++ b/Frontend.Angular/src/app/models/user.ts
@@ -25,8 +25,10 @@ export interface User {
   profileVerified: string[]; // An array of verification methods like Email, Mobile
   lessonsCompleted: number | null; // Number of lessons completed
   evaluations: number | null; // The number of evaluations
-  profileImagePath: string; // Path or URL to the profile image
-  profileImage: File; // Path or URL to the profile image
+  // Backend returns the image URL as `imageUrl`. Map it to `profileImagePath` for existing components.
+  profileImagePath?: string; // Path or URL to the profile image
+  imageUrl?: string;          // Raw field from backend
+  profileImage?: File;
   recommendationToken: string;
   isStripeConnected: boolean;
   isPayPalConnected: boolean;

--- a/Frontend.Angular/src/app/services/user.service.ts
+++ b/Frontend.Angular/src/app/services/user.service.ts
@@ -32,6 +32,7 @@ export class UserService {
     // Fetch from backend if not found locally
     return this.http.get<User>(`${this.apiUrl}/me`).pipe(
       tap(user => {
+        this.mapProfileImage(user);
         this.cachedUser = user;
         localStorage.setItem('user', JSON.stringify(user));
       })
@@ -61,6 +62,7 @@ export class UserService {
     this.clearCachedUser();
     return this.http.get<User>(`${this.apiUrl}/me`).pipe(
       tap(user => {
+        this.mapProfileImage(user);
         this.cachedUser = user;
         localStorage.setItem('user', JSON.stringify(user));
       })
@@ -154,12 +156,13 @@ export class UserService {
           }),
           switchMap(() => {
             // Fetch fresh user data from the server
-            return this.http.get<User>(`${this.apiUrl}/me`).pipe(
-              tap(updatedUser => {
-                // Update the cache with fresh data
-                this.cachedUser = updatedUser;
-                localStorage.setItem('user', JSON.stringify(this.cachedUser));
-              }),
+          return this.http.get<User>(`${this.apiUrl}/me`).pipe(
+            tap(updatedUser => {
+              // Update the cache with fresh data
+              this.mapProfileImage(updatedUser);
+              this.cachedUser = updatedUser;
+              localStorage.setItem('user', JSON.stringify(this.cachedUser));
+            }),
               map(() => void 0) // Convert to void to match return type
             );
           })
@@ -212,5 +215,11 @@ export class UserService {
 
   deleteAccount(): Observable<void> {
     return this.http.delete<void>(`${this.apiUrl}/me`);
+  }
+
+  private mapProfileImage(user: any): void {
+    if (user && !user.profileImagePath && user.imageUrl) {
+      user.profileImagePath = user.imageUrl;
+    }
   }
 }

--- a/api/Avancira.Infrastructure/Identity/Users/Services/UserService.cs
+++ b/api/Avancira.Infrastructure/Identity/Users/Services/UserService.cs
@@ -185,8 +185,9 @@ internal sealed partial class UserService(
                 using var memoryStream = new MemoryStream();
                 await request.Image.CopyToAsync(memoryStream);
                 var fileBytes = memoryStream.ToArray();
-                var base64String = Convert.ToBase64String(fileBytes);
-                
+                var base64Data = Convert.ToBase64String(fileBytes);
+                var base64String = $"data:{request.Image.ContentType};base64,{base64Data}";
+
                 fileUploadDto = new FileUploadDto
                 {
                     Name = request.Image.FileName,


### PR DESCRIPTION
## Summary
- include content type prefix when uploading profile images
- expose `imageUrl` field in Angular `User` model
- map `imageUrl` to `profileImagePath` when fetching user data

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686768d5bf8483289ddca058072a34f9