### PR TITLE
Improve bio section labeling and validation

### DIFF
--- a/Frontend.Angular/src/app/pages/profile/profile.component.html
+++ b/Frontend.Angular/src/app/pages/profile/profile.component.html
@@ -107,9 +107,10 @@
                     <div class="card mb-4">
                         <div class="card-body">
                             <div class="mb-3">
-                                <label class="form-label">Short Bio</label>
-                                <textarea class="form-control" rows="4" name="bio" [(ngModel)]="profile.bio"
-                                    placeholder="Write a short bio about yourself"></textarea>
+                                <label class="form-label">About You <small class="text-muted">(max 500 characters)</small></label>
+                                <textarea class="form-control" rows="4" name="bio" [(ngModel)]="profile.bio" maxlength="500"
+                                    placeholder="Tell us about yourself"></textarea>
+                                <small class="text-muted">{{ (profile.bio?.length || 0) }}/500</small>
                             </div>
                             <!-- Save Bio Button -->
                             <div class="text-center">

--- a/api/Avancira.Application/Identity/Users/Dtos/UpdateUserDto.cs
+++ b/api/Avancira.Application/Identity/Users/Dtos/UpdateUserDto.cs
@@ -13,6 +13,7 @@ public class UpdateUserDto
     public string? DateOfBirth { get; set; }
     public string? SkypeId { get; set; }
     public string? HangoutId { get; set; }
+    [MaxLength(500)]
     public string? Bio { get; set; }
     public string? TimeZoneId { get; set; }
     public IFormFile? Image { get; set; }


### PR DESCRIPTION
## Summary
- rename the bio section label to "About You" and show a character count
- restrict the textarea to 500 characters
- enforce a max length of 500 characters in the `UpdateUserDto`

## Testing
- `npm exec ng test -- --watch=false --browsers=ChromeHeadless` *(fails: could not determine executable)*
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6867738ed6ac8328a36a79d513eb25c8