### PR TITLE
Unify profile image naming

### DIFF
--- a/Frontend.Angular/src/app/components/message-list/message-list.component.html
+++ b/Frontend.Angular/src/app/components/message-list/message-list.component.html
@@ -1,6 +1,6 @@
 <form class="chat-search d-flex align-items-center">
   <div class="avatar avatar-online me-3">
-    <img [src]="user.profileImagePath" alt="User Image" class="avatar-img rounded-circle" [imageFallback]="user.firstName + ' ' + user.lastName">
+    <img [src]="user.imageUrl" alt="User Image" class="avatar-img rounded-circle" [imageFallback]="user.firstName + ' ' + user.lastName">
   </div>
   <div class="input-group">
     <div class="input-group-prepend">
@@ -19,7 +19,7 @@
       [class.active]="contact.id === selectedContact?.id" (click)="selectContact(contact)">
       <div class="media-img-wrap flex-shrink-0">
         <div class="avatar avatar-online">
-          <img [src]="contact.profileImagePath" alt="User Image" class="avatar-img rounded-circle">
+          <img [src]="contact.imageUrl" alt="User Image" class="avatar-img rounded-circle">
         </div>
       </div>
       <div class="media-body flex-grow-1">

--- a/Frontend.Angular/src/app/components/message-thread/message-thread.component.html
+++ b/Frontend.Angular/src/app/components/message-thread/message-thread.component.html
@@ -11,7 +11,7 @@
     <div class="media d-flex">
       <div class="media-img-wrap flex-shrink-0">
         <div class="avatar avatar-online">
-          <img [src]="selectedContact.profileImagePath" alt="User Image" class="avatar-img rounded-circle">
+          <img [src]="selectedContact.imageUrl" alt="User Image" class="avatar-img rounded-circle">
         </div>
       </div>
       <div class="media-body flex-grow-1">

--- a/Frontend.Angular/src/app/components/profile-details/profile-details.component.html
+++ b/Frontend.Angular/src/app/components/profile-details/profile-details.component.html
@@ -51,7 +51,7 @@
     <!-- Profile Photo -->
     <div class="profile-section">
         <h4>Profile Photo 📸</h4>
-        <app-profile-image [profileImagePath]="profile.profileImagePath" [firstName]="profile.firstName"
+        <app-profile-image [imageUrl]="profile.imageUrl" [firstName]="profile.firstName"
             [lastName]="profile.lastName" sizeClass="large"></app-profile-image>
 
         <button class="upload-btn" (click)="onProfilePictureUpload()">📤</button>

--- a/Frontend.Angular/src/app/components/profile-details/profile-details.component.ts
+++ b/Frontend.Angular/src/app/components/profile-details/profile-details.component.ts
@@ -102,7 +102,7 @@ export class ProfileDetailsComponent implements OnInit {
       if (file) {
         const reader = new FileReader();
         reader.onload = () => {
-          if (this.profile) this.profile.profileImagePath = reader.result as string;
+          if (this.profile) this.profile.imageUrl = reader.result as string;
 
           this.userService.updateUser(this.profile!, file).subscribe({
             error: (err) => console.error('Error updating profile picture:', err)

--- a/Frontend.Angular/src/app/components/profile-image/profile-image.component.html
+++ b/Frontend.Angular/src/app/components/profile-image/profile-image.component.html
@@ -2,7 +2,7 @@
   <!-- Display the image if available and no error -->
   <img
     *ngIf="showImage"
-    [src]="profileImagePath"
+    [src]="imageUrl"
     alt="Profile Photo"
     [class]="'pro-avatar profile-photo ' + (customClass || '')"
     (error)="isImageError = true"

--- a/Frontend.Angular/src/app/components/profile-image/profile-image.component.ts
+++ b/Frontend.Angular/src/app/components/profile-image/profile-image.component.ts
@@ -9,7 +9,7 @@ import { FormsModule } from '@angular/forms';
   styleUrl: './profile-image.component.scss'
 })
 export class ProfileImageComponent {
-  @Input() profileImagePath?: string; // Profile image path
+  @Input() imageUrl?: string; // Profile image path
   @Input() firstName?: string;    // User's first name
   @Input() lastName?: string;     // User's last name
   @Input() sizeClass: string = 'large'; // Default size is 'medium'
@@ -24,6 +24,6 @@ export class ProfileImageComponent {
 
   get showImage(): boolean {
     // Show the image only if profileImage is defined, non-empty, and no error occurred
-    return !!this.profileImagePath && !this.isImageError;
+    return !!this.imageUrl && !this.isImageError;
   }
 }

--- a/Frontend.Angular/src/app/layout/shared/header/header.component.html
+++ b/Frontend.Angular/src/app/layout/shared/header/header.component.html
@@ -56,15 +56,15 @@
         <li class="nav-item dropdown has-arrow logged-item" *ngIf="isLoggedIn()">
           <a href="#" class="dropdown-toggle nav-link" data-bs-toggle="dropdown" aria-expanded="false">
             <span class="user-img">
-              <img [src]="user.profileImagePath" alt="" class="avatar-img rounded-circle" [imageFallback]="user.firstName + ' ' + user.lastName">
+              <img [src]="user.imageUrl" alt="" class="avatar-img rounded-circle" [imageFallback]="user.firstName + ' ' + user.lastName">
 
-              <!-- <img class="rounded-circle" [src]="user.profileImagePath" width="31" alt=""> -->
+              <!-- <img class="rounded-circle" [src]="user.imageUrl" width="31" alt=""> -->
             </span>
           </a>
           <div class="dropdown-menu dropdown-menu-end">
             <div class="user-header">
               <div class="avatar avatar-sm">
-                <img [src]="user.profileImagePath" alt="" class="avatar-img rounded-circle" [imageFallback]="user.firstName + ' ' + user.lastName">
+                <img [src]="user.imageUrl" alt="" class="avatar-img rounded-circle" [imageFallback]="user.firstName + ' ' + user.lastName">
 
                 <!-- <ng-template #defaultImage>
                     <img src="assets/img/user/user.jpg" alt="" class="avatar-img rounded-circle">

--- a/Frontend.Angular/src/app/layout/shared/sidebar/sidebar.component.html
+++ b/Frontend.Angular/src/app/layout/shared/sidebar/sidebar.component.html
@@ -1,7 +1,7 @@
 <!-- Sidebar -->
 <div class="profile-sidebar">
     <div class="user-widget">
-        <app-profile-image [profileImagePath]="user.profileImagePath" [firstName]="user.firstName"
+        <app-profile-image [imageUrl]="user.imageUrl" [firstName]="user.firstName"
             [lastName]="user.lastName"></app-profile-image>
         <div class="rating">
             <i class="fas fa-star filled"></i>

--- a/Frontend.Angular/src/app/models/chat.ts
+++ b/Frontend.Angular/src/app/models/chat.ts
@@ -6,7 +6,7 @@ export interface Chat {
     studentId: string;
     recipientId: string;
     name: string;
-    profileImagePath: string;
+    imageUrl: string;
     lastMessage: string;
     timestamp: Date;
     details: string;

--- a/Frontend.Angular/src/app/models/user.ts
+++ b/Frontend.Angular/src/app/models/user.ts
@@ -25,9 +25,8 @@ export interface User {
   profileVerified: string[]; // An array of verification methods like Email, Mobile
   lessonsCompleted: number | null; // Number of lessons completed
   evaluations: number | null; // The number of evaluations
-  // Backend returns the image URL as `imageUrl`. Map it to `profileImagePath` for existing components.
-  profileImagePath?: string; // Path or URL to the profile image
-  imageUrl?: string;          // Raw field from backend
+  /** URL to the user's profile image */
+  imageUrl?: string;
   profileImage?: File;
   recommendationToken: string;
   isStripeConnected: boolean;

--- a/Frontend.Angular/src/app/pages/dashboard/dashboard.component.html
+++ b/Frontend.Angular/src/app/pages/dashboard/dashboard.component.html
@@ -113,7 +113,7 @@
                 <ul class="list-group">
                   <li class="list-group-item" *ngFor="let listing of listings | slice:0:5">
                     <div class="d-flex align-items-center">
-                      <app-profile-image [profileImagePath]="listing.listingImagePath" [firstName]="listing.tutorName" [lastName]=""></app-profile-image>
+                      <app-profile-image [imageUrl]="listing.listingImagePath" [firstName]="listing.tutorName" [lastName]=""></app-profile-image>
                       <div class="ml-3">
                         <h4>{{ listing.title }}</h4>
                         <p>{{ listing.lessonCategory }}</p>

--- a/Frontend.Angular/src/app/pages/profile/profile.component.html
+++ b/Frontend.Angular/src/app/pages/profile/profile.component.html
@@ -19,7 +19,7 @@
                             <div class="form-group">
                                 <div class="change-avatar">
                                     <div class="profile-img">
-                                        <img [src]="profile.profileImagePath" alt="User Image"
+                                        <img [src]="profile.imageUrl" alt="User Image"
                                             [imageFallback]="profile.firstName + ' ' + profile.lastName">
                                     </div>
                                     <div class="upload-img">

--- a/Frontend.Angular/src/app/pages/profile/profile.component.ts
+++ b/Frontend.Angular/src/app/pages/profile/profile.component.ts
@@ -163,8 +163,8 @@ export class ProfileComponent implements OnInit {
       const reader = new FileReader();
       reader.onload = () => {
         if (this.profile) {
-          // Set the image path on the profile object
-          this.profile.profileImagePath = reader.result as string;
+          // Set the image URL on the profile object
+          this.profile.imageUrl = reader.result as string;
         }
   
         // Send the image file to the server

--- a/Frontend.Angular/src/app/pages/recommendation-submission/recommendation-submission.component.ts
+++ b/Frontend.Angular/src/app/pages/recommendation-submission/recommendation-submission.component.ts
@@ -51,7 +51,7 @@ export class RecommendationSubmissionComponent implements OnInit {
       next: (user) => {
         this.recommendation.revieweeId = user.id;
         this.recommendation.name = user.fullName;
-        this.recommendation.avatar = user.profileImagePath || null;
+        this.recommendation.avatar = user.imageUrl || null;
       },
       error: (err) => {
         console.error('Error fetching user details:', err);

--- a/Frontend.Angular/src/app/services/user.service.ts
+++ b/Frontend.Angular/src/app/services/user.service.ts
@@ -25,6 +25,9 @@ export class UserService {
     if (storedUser) {
       this.cachedUser = JSON.parse(storedUser);
       if (this.cachedUser) {
+        if ((this.cachedUser as any).profileImagePath && !(this.cachedUser as any).imageUrl) {
+          (this.cachedUser as any).imageUrl = (this.cachedUser as any).profileImagePath;
+        }
         return of(this.cachedUser);
       }
     }
@@ -32,7 +35,6 @@ export class UserService {
     // Fetch from backend if not found locally
     return this.http.get<User>(`${this.apiUrl}/me`).pipe(
       tap(user => {
-        this.mapProfileImage(user);
         this.cachedUser = user;
         localStorage.setItem('user', JSON.stringify(user));
       })
@@ -62,7 +64,6 @@ export class UserService {
     this.clearCachedUser();
     return this.http.get<User>(`${this.apiUrl}/me`).pipe(
       tap(user => {
-        this.mapProfileImage(user);
         this.cachedUser = user;
         localStorage.setItem('user', JSON.stringify(user));
       })
@@ -159,7 +160,6 @@ export class UserService {
           return this.http.get<User>(`${this.apiUrl}/me`).pipe(
             tap(updatedUser => {
               // Update the cache with fresh data
-              this.mapProfileImage(updatedUser);
               this.cachedUser = updatedUser;
               localStorage.setItem('user', JSON.stringify(this.cachedUser));
             }),
@@ -217,9 +217,4 @@ export class UserService {
     return this.http.delete<void>(`${this.apiUrl}/me`);
   }
 
-  private mapProfileImage(user: any): void {
-    if (user && !user.profileImagePath && user.imageUrl) {
-      user.profileImagePath = user.imageUrl;
-    }
-  }
 }

--- a/api/Avancira.Application/Identity/Users/Dtos/UserDto.cs
+++ b/api/Avancira.Application/Identity/Users/Dtos/UserDto.cs
@@ -17,7 +17,8 @@ namespace Avancira.Application.Catalog.Dtos
         public string? Email { get; set; }
         public DateTime? DateOfBirth { get; set; }
         public string? PhoneNumber { get; set; }
-        public string? ProfileImagePath { get; set; }
+        // URL pointing to the user's profile image
+        public string? ImageUrl { get; set; }
         public IFormFile? ProfileImage { get; set; }
         public AddressDto? Address { get; set; }
         public string? TimeZoneId { get; set; } = "Austarlia/Sydney";

--- a/api/Avancira.Application/Messaging/Dtos/ChatDto.cs
+++ b/api/Avancira.Application/Messaging/Dtos/ChatDto.cs
@@ -15,7 +15,8 @@ namespace Avancira.Application.Messaging.Dtos
         public string StudentId { get; set; }
         public string RecipientId { get; set; }
         public string Name { get; set; }
-        public string ProfileImagePath { get; set; }
+        // URL for the profile image of the chat participant
+        public string ImageUrl { get; set; }
         public string LastMessage { get; set; }
         public DateTime Timestamp { get; set; }
         public string Details { get; set; }
@@ -25,7 +26,7 @@ namespace Avancira.Application.Messaging.Dtos
         public ChatDto()
         {
             Name = string.Empty;
-            ProfileImagePath = string.Empty;
+            ImageUrl = string.Empty;
             TutorId = string.Empty;
             StudentId = string.Empty;
             RecipientId = string.Empty;

--- a/api/Avancira.Infrastructure/Messaging/ChatService.cs
+++ b/api/Avancira.Infrastructure/Messaging/ChatService.cs
@@ -87,7 +87,7 @@ namespace Avancira.Infrastructure.Catalog
                             ? $"{x.CategoryName} {(isStudent ? "Tutor" : "Student")}"
                             : "No lesson category",
                         Name = $"{recipient.FirstName} {recipient.LastName}",
-                        ProfileImagePath = recipient.ImageUrl?.ToString() ?? "",
+                        ImageUrl = recipient.ImageUrl?.ToString() ?? string.Empty,
                         LastMessage = latestMessage?.Content ?? "No messages yet",
                         Timestamp = latestMessage?.SentAt.DateTime ?? x.Chat.CreatedAt.DateTime,
                         Messages = messages.Select(m => new MessageDto
@@ -158,7 +158,7 @@ namespace Avancira.Infrastructure.Catalog
                     ? $"{x.CategoryName} {(isStudent ? "Tutor" : "Student")}"
                     : "No lesson category",
                 Name = $"{recipient.FirstName} {recipient.LastName}",
-                ProfileImagePath = recipient.ImageUrl?.ToString() ?? string.Empty,
+                ImageUrl = recipient.ImageUrl?.ToString() ?? string.Empty,
                 LastMessage = latestMessage?.Content ?? "No messages yet",
                 Timestamp = latestMessage?.SentAt.DateTime ?? x.Chat.CreatedAt.DateTime,
                 Messages = messages.Select(m => new MessageDto


### PR DESCRIPTION
## Summary
- unify user profile image naming between backend and frontend
- remove old `profileImagePath` usages and migrate to `imageUrl`
- keep backward compatibility when reading cached user data

## Testing
- `npm test --prefix Frontend.Angular` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_b_6867721ac03c8328ab67b6a9c80f38c3