### PR TITLE
Fix profile image view update

### DIFF
--- a/Frontend.Angular/src/app/directives/image-fallback.directive.ts
+++ b/Frontend.Angular/src/app/directives/image-fallback.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, HostListener, Input, OnInit,Renderer2 } from '@angular/core';
+import { Directive, ElementRef, HostListener, Input, OnInit, Renderer2 } from '@angular/core';
 
 @Directive({
   selector: '[imageFallback]'
@@ -7,52 +7,62 @@ export class ImageFallbackDirective implements OnInit {
   @Input('imageFallback') fullName: string = 'U U'; // Default initials
 
   private imgElement: HTMLImageElement;
-  private containerDiv: HTMLDivElement | undefined;
+  private fallbackDiv: HTMLDivElement;
 
   constructor(private el: ElementRef, private renderer: Renderer2) {
     this.imgElement = this.el.nativeElement as HTMLImageElement;
+    this.fallbackDiv = this.renderer.createElement('div');
   }
 
   ngOnInit() {
+    this.setupFallbackDiv();
     if (!this.imgElement.src) {
-      this.replaceWithInitials();
+      this.showFallback();
     }
   }
 
   @HostListener('error')
   onError() {
-    this.replaceWithInitials();
+    this.showFallback();
   }
 
-  private replaceWithInitials() {
-    const parent = this.imgElement.parentElement;
-    
-    // Create initials div
-    this.containerDiv = this.renderer.createElement('div');
-    this.renderer.setStyle(this.containerDiv, 'display', 'flex');
-    this.renderer.setStyle(this.containerDiv, 'align-items', 'center');
-    this.renderer.setStyle(this.containerDiv, 'justify-content', 'center');
-    this.renderer.setStyle(this.containerDiv, 'background', '#ccc'); // Default background color
-    this.renderer.setStyle(this.containerDiv, 'color', '#fff'); // Text color
-    this.renderer.setStyle(this.containerDiv, 'font-weight', 'bold');
-    this.renderer.setStyle(this.containerDiv, 'font-size', '1.2rem');
-    this.renderer.setStyle(this.containerDiv, 'border-radius', '50%');
-    this.renderer.setStyle(this.containerDiv, 'overflow', 'hidden');
+  @HostListener('load')
+  onLoad() {
+    this.showImage();
+  }
 
-    // Get initials from name
+  private setupFallbackDiv() {
+    const parent = this.imgElement.parentElement;
+    if (!parent) return;
+
+    this.renderer.setStyle(this.fallbackDiv, 'display', 'flex');
+    this.renderer.setStyle(this.fallbackDiv, 'align-items', 'center');
+    this.renderer.setStyle(this.fallbackDiv, 'justify-content', 'center');
+    this.renderer.setStyle(this.fallbackDiv, 'background', '#ccc'); // Default background color
+    this.renderer.setStyle(this.fallbackDiv, 'color', '#fff');
+    this.renderer.setStyle(this.fallbackDiv, 'font-weight', 'bold');
+    this.renderer.setStyle(this.fallbackDiv, 'font-size', '1.2rem');
+    this.renderer.setStyle(this.fallbackDiv, 'border-radius', '50%');
+    this.renderer.setStyle(this.fallbackDiv, 'overflow', 'hidden');
+    this.renderer.setStyle(this.fallbackDiv, 'width', `${this.imgElement.width || 100}px`);
+    this.renderer.setStyle(this.fallbackDiv, 'height', `${this.imgElement.height || 100}px`);
+
     const initials = this.getInitials(this.fullName);
     const textNode = this.renderer.createText(initials);
-    this.renderer.appendChild(this.containerDiv, textNode);
+    this.renderer.appendChild(this.fallbackDiv, textNode);
 
-    // Copy width & height from original image
-    this.renderer.setStyle(this.containerDiv, 'width', `${this.imgElement.clientWidth}px`);
-    this.renderer.setStyle(this.containerDiv, 'height', `${this.imgElement.clientHeight}px`);
+    this.renderer.insertBefore(parent, this.fallbackDiv, this.imgElement.nextSibling);
+    this.renderer.setStyle(this.fallbackDiv, 'display', 'none');
+  }
 
-    // Replace image with initials div
-    if (parent) {
-      this.renderer.removeChild(parent, this.imgElement);
-      this.renderer.appendChild(parent, this.containerDiv);
-    }
+  private showFallback() {
+    this.renderer.setStyle(this.imgElement, 'display', 'none');
+    this.renderer.setStyle(this.fallbackDiv, 'display', 'flex');
+  }
+
+  private showImage() {
+    this.renderer.setStyle(this.imgElement, 'display', 'block');
+    this.renderer.setStyle(this.fallbackDiv, 'display', 'none');
   }
 
   private getInitials(name: string): string {


### PR DESCRIPTION
## Summary
- ensure profile image updates instantly by keeping fallback avatar in DOM

## Testing
- `npm test` *(fails: ng not found)*
- `npx ng test --watch=false` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_b_68677b0a35688328979122bd0d322018