### PR TITLE
Fix profile image preview and update propagation

### DIFF
--- a/Frontend.Angular/src/app/layout/shared/header/header.component.ts
+++ b/Frontend.Angular/src/app/layout/shared/header/header.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
 
 import { AuthService } from '../../../services/auth.service';
@@ -8,6 +8,7 @@ import { UserService } from '../../../services/user.service';
 import { ImageFallbackDirective } from '../../../directives/image-fallback.directive';
 
 import { User } from '../../../models/user';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-header',
@@ -15,11 +16,13 @@ import { User } from '../../../models/user';
   templateUrl: './header.component.html',
   styleUrl: './header.component.scss'
 })
-export class HeaderComponent {
+
+export class HeaderComponent implements OnInit, OnDestroy {
   isMenuOpen = false;
   roles: string[] = [];
   currentRole: 'student' | 'tutor' = 'student';
   user!: User;
+  private userSub?: Subscription;
 
 
   constructor(
@@ -31,6 +34,9 @@ export class HeaderComponent {
 
   ngOnInit(): void {
     if (this.isLoggedIn()) {
+      this.userSub = this.userService.user$.subscribe(user => {
+        if (user) this.user = user;
+      });
       this.fetchUserInfo();
     }
     this.roles = this.authService.getRoles();
@@ -42,6 +48,10 @@ export class HeaderComponent {
       this.currentRole = this.roles[0] as 'student' | 'tutor';
       this.authService.saveCurrentRole(this.currentRole);
     }
+  }
+
+  ngOnDestroy(): void {
+    this.userSub?.unsubscribe();
   }
 
   switchRole(role: 'student' | 'tutor'): void {

--- a/Frontend.Angular/src/app/layout/shared/sidebar/sidebar.component.ts
+++ b/Frontend.Angular/src/app/layout/shared/sidebar/sidebar.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, NavigationEnd, Router, RouterModule } from '@angular/router';
-import { filter } from 'rxjs';
+import { filter, Subscription } from 'rxjs';
 
 import { ProfileImageComponent } from '../../../components/profile-image/profile-image.component';
 
@@ -15,9 +15,10 @@ import { User } from '../../../models/user';
   templateUrl: './sidebar.component.html',
   styleUrl: './sidebar.component.scss'
 })
-export class SidebarComponent implements OnInit {
+export class SidebarComponent implements OnInit, OnDestroy {
   currentPage: string = 'Home'; // Default breadcrumb title
   user!: User;
+  private userSub?: Subscription;
 
   constructor(
     private userService: UserService,
@@ -44,10 +45,16 @@ export class SidebarComponent implements OnInit {
       }
     });
 
+    this.userSub = this.userService.user$.subscribe(userData => {
+      if (userData) this.user = userData;
+    });
     this.userService.getUser().subscribe({
-      next: (userData) => (this.user = userData),
       error: (err) => console.error('Failed to load user data:', err),
     });
+  }
+
+  ngOnDestroy(): void {
+    this.userSub?.unsubscribe();
   }
 
 }

--- a/Frontend.Angular/src/app/pages/profile/profile.component.html
+++ b/Frontend.Angular/src/app/pages/profile/profile.component.html
@@ -24,7 +24,7 @@
                                     </div>
                                     <div class="upload-img">
                                         <div class="change-photo-btn">
-                                            <span><i class="fa fa-upload"></i> Upload Photo</span>
+                                            <span><i class="fa fa-upload"></i> Choose Photo</span>
                                             <input type="file" accept="image/*" class="upload" (change)="onProfilePictureUpload($event)">
                                         </div>
                                         <small class="form-text text-muted">Allowed JPG, GIF or PNG. Max size of


### PR DESCRIPTION
## Summary
- emit profile changes through a new `user$` observable in `UserService`
- preview selected profile image without immediate upload
- update header and sidebar when the user data changes
- rename photo picker button to *Choose Photo*

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_b_68677dd25b148328899e2d22a9616eed