### PR TITLE
Persist database between Aspire runs

### DIFF
--- a/api/Avancira.Infrastructure/Persistence/DBSeeding.cs
+++ b/api/Avancira.Infrastructure/Persistence/DBSeeding.cs
@@ -103,7 +103,7 @@ public class UserSeeder
 {
     public static void Seed(AvanciraDbContext context, UserManager<User> userManager)
     {
-        //if (!context.Users.Any())
+        if (!context.Users.Any())
         {
             var users = new List<User>
             {

--- a/aspire/Avancira.Host/Program.cs
+++ b/aspire/Avancira.Host/Program.cs
@@ -25,7 +25,9 @@ var grafana = builder.AddContainer("grafana", "grafana/grafana:latest")
 
 // PostgreSQL
 var postgresPassword = builder.AddParameter("postgres-password", "Avancira@2025", secret: true);
-var postgresql = builder.AddPostgres("postgresql", password: postgresPassword);
+var postgresql = builder.AddPostgres("postgresql", password: postgresPassword)
+    // Persist database files across runs so tokens remain valid
+    .WithVolumeMount("pgdata", "/var/lib/postgresql/data");
 
 var postgresDb = postgresql.AddDatabase("avancira");
 


### PR DESCRIPTION
## Summary
- keep Postgres data when running the Aspire host by mounting a volume
- avoid inserting duplicate users when seeding the database

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6867826b490883288bd97811294f2eb9