### PR TITLE
Fix user seeding passwords

### DIFF
--- a/api/Avancira.Infrastructure/Persistence/DBSeeding.cs
+++ b/api/Avancira.Infrastructure/Persistence/DBSeeding.cs
@@ -529,12 +529,10 @@ public class UserSeeder
 
             };
 
-            var password = new PasswordHasher<User>();
             foreach (var user in users)
             {
                 user.Id = Guid.NewGuid().ToString();
-                user.PasswordHash = password.HashPassword(user, AppConstants.DefaultPassword);
-                userManager.CreateAsync(user).GetAwaiter().GetResult();
+                userManager.CreateAsync(user, AppConstants.DefaultPassword).GetAwaiter().GetResult();
                 userManager.AddToRoleAsync(user, AvanciraRoles.Basic).GetAwaiter().GetResult();
             }
         }

--- a/api/Avancira.Infrastructure/Persistence/IdentityDbInitializer.cs
+++ b/api/Avancira.Infrastructure/Persistence/IdentityDbInitializer.cs
@@ -107,9 +107,7 @@ internal sealed class IdentityDbInitializer(
             };
 
             logger.LogInformation("Seeding default Admin user");
-            var password = new PasswordHasher<User>();
-            adminUser.PasswordHash = password.HashPassword(adminUser, AppConstants.DefaultPassword);
-            await userManager.CreateAsync(adminUser);
+            await userManager.CreateAsync(adminUser, AppConstants.DefaultPassword);
         }
 
         if (!await userManager.IsInRoleAsync(adminUser, AvanciraRoles.Admin))


### PR DESCRIPTION
## Summary
- ensure seeded users use `UserManager` to hash passwords
- update admin user seeding to use `UserManager`

## Testing
- `dotnet test` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_b_686787ee51b483289c3c9cd68878216a