### PR TITLE
Add environment configs for dev

### DIFF
--- a/Frontend.Angular/src/index.html
+++ b/Frontend.Angular/src/index.html
@@ -45,7 +45,7 @@
   <meta name="robots" content="index, follow">
 
   <!-- Content Security Policy -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://maps.googleapis.com https://connect.facebook.net https://meet.jit.si https://client.crisp.chat https://js.stripe.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://client.crisp.chat; font-src 'self' https://fonts.gstatic.com https://client.crisp.chat data:; img-src 'self' data: https:; connect-src 'self' https: wss://client.relay.crisp.chat wss://localhost:9000; frame-src 'self' https://meet.jit.si https://js.stripe.com;">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://maps.googleapis.com https://connect.facebook.net https://meet.jit.si https://client.crisp.chat https://js.stripe.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://client.crisp.chat; font-src 'self' https://fonts.gstatic.com https://client.crisp.chat data:; img-src 'self' data: https:; connect-src 'self' https: wss://client.relay.crisp.chat wss://localhost:9000 wss://www.avancira.com; frame-src 'self' https://meet.jit.si https://js.stripe.com;">
   <!-- Structured Data for SEO -->
   <script src="https://connect.facebook.net/en_US/sdk.js" async defer crossorigin="anonymous"></script>
   <script type="application/ld+json">

--- a/admin/Client/wwwroot/appsettings.Development.json
+++ b/admin/Client/wwwroot/appsettings.Development.json
@@ -1,0 +1,3 @@
+{
+  "ApiBaseUrl": "https://localhost:9000/"
+}

--- a/admin/Client/wwwroot/appsettings.json
+++ b/admin/Client/wwwroot/appsettings.json
@@ -1,3 +1,3 @@
 ﻿{
-  "ApiBaseUrl": "https://localhost:9000/"
+  "ApiBaseUrl": "https://www.avancira.com/"
 }

--- a/api/Avancira.API/appsettings.Development.json
+++ b/api/Avancira.API/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "OriginOptions": {
+    "OriginUrl": "https://localhost:9000"
   }
 }

--- a/api/Avancira.API/appsettings.json
+++ b/api/Avancira.API/appsettings.json
@@ -4,7 +4,7 @@
     "ConnectionString": "Host={Avancira__Database__Host};Port={Avancira__Database__Port};Database={Avancira__Database__Name};Username={Avancira__Database__User};Password={Avancira__Database__Password}"
   },
   "OriginOptions": {
-    "OriginUrl": "https://localhost:9000"
+    "OriginUrl": "https://www.avancira.com"
   },
   "CacheOptions": {
     "Redis": ""


### PR DESCRIPTION
## Summary
- allow localhost and production domains in CSP
- override API origin in `appsettings.Development.json`
- add development settings for admin client

## Testing
- `npm test --silent` *(fails: ng not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68679e29458883289a94dd0aa3b2f8f0