### PR TITLE
Fix asset proxy

### DIFF
--- a/Frontend.Angular/nginx.conf
+++ b/Frontend.Angular/nginx.conf
@@ -15,6 +15,24 @@ server {
 
     root /usr/share/nginx/html;
 
+    # Proxy API requests to the backend container
+    location /api/ {
+        proxy_pass http://avancira-backend-container:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Proxy static asset requests such as profile images
+    location /assets/ {
+        proxy_pass http://avancira-backend-container:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location / {
         try_files $uri $uri/ /index.html =404;
     }

--- a/Frontend.Angular/src/app/environments/environment.prod.ts
+++ b/Frontend.Angular/src/app/environments/environment.prod.ts
@@ -1,7 +1,6 @@
 export const environment = {
-    baseApiUrl: 'https://www.avancira.com',
-    apiUrl: `https://www.avancira.com/api`,
-    frontendUrl: 'https://www.avancira.com',
-    useSignalR: true,
-  };
-  
+  baseApiUrl: 'https://www.avancira.com',
+  apiUrl: `https://www.avancira.com/api`,
+  frontendUrl: 'https://www.avancira.com',
+  useSignalR: true,
+};


### PR DESCRIPTION
## Summary
- route `/api` and `/assets` paths to backend container
- clean prod environment file

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6867b2eb024c8328b24b3dfad370133d