### PR TITLE
Reschedule token refresh after refreshing access token

### DIFF
--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -88,7 +88,13 @@ export class AuthService implements OnDestroy {
             Token: token,
             RefreshToken: refreshToken
         }).pipe(
-            tap(res => res?.token && this.applyTokens(res, false)),
+            tap(res => {
+                if (res?.token) {
+                    this.applyTokens(res, false);
+                    const { exp } = this.decodeToken(res.token);
+                    if (exp) this.scheduleRefresh(exp);
+                }
+            }),
             catchError(err => {
                 this.logout();
                 return this.handleError(err);


### PR DESCRIPTION
## Summary
- Reschedule access token refresh after a successful refresh token call by decoding the new JWT's exp claim

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: Cannot find exported members and missing resources in tests)*

------
https://chatgpt.com/codex/tasks/task_e_689cdd2d090483279d1c14043563f5f3