### PR TITLE
fix: validate refresh token presence

### DIFF
--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -67,7 +67,11 @@ export class AuthService implements OnDestroy {
     isAuthenticated(): boolean {
         return !!(
             (this.accessToken && this.tokenExpiryMs(this.accessToken) > Date.now()) ||
-            (this.getStorage(this.REFRESH_EXPIRY_KEY) && Date.parse(this.getStorage(this.REFRESH_EXPIRY_KEY)!) > Date.now())
+            (
+                this.getStorage(this.REFRESH_TOKEN_KEY) &&
+                this.getStorage(this.REFRESH_EXPIRY_KEY) &&
+                Date.parse(this.getStorage(this.REFRESH_EXPIRY_KEY)!) > Date.now()
+            )
         );
     }
 


### PR DESCRIPTION
## Summary
- ensure refresh token exists and is not expired before treating a session as authenticated

## Testing
- `npm test` *(fails: No binary for Chrome browser; TS2724: GridStateServiceService not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cdd489c088327bfa3f7a7d141cb8d