### PR TITLE
refactor(auth): replace localStorage token handling

### DIFF
--- a/Frontend.Angular/src/app/components/payment-alt-options/payment-alt-options.component.ts
+++ b/Frontend.Angular/src/app/components/payment-alt-options/payment-alt-options.component.ts
@@ -6,6 +6,7 @@ import { ConfigService } from '../../services/config.service';
 import { ListingService } from '../../services/listing.service';
 import { PaymentService } from '../../services/payment.service';
 import { SubscriptionService } from '../../services/subscription.service';
+import { AuthService } from '../../services/auth.service';
 
 
 
@@ -36,12 +37,13 @@ export class PaymentAltOptionsComponent implements OnInit {
     private listingService: ListingService,
     private paymentService: PaymentService,
     private subscriptionService: SubscriptionService,
-    private configService: ConfigService
+    private configService: ConfigService,
+    private authService: AuthService
   ) { }
 
 
   ngOnInit(): void {
-    this.isLoggedIn = !!localStorage.getItem('token'); // Check if token exists
+    this.isLoggedIn = this.authService.isAuthenticated(); // Check if token exists
     this.stripePromise = loadStripe(this.configService.get('stripePublishableKey'));
 
     this.paymentService.loadPayPalScript().then(() => {

--- a/Frontend.Angular/src/app/pages/payment/payment.component.ts
+++ b/Frontend.Angular/src/app/pages/payment/payment.component.ts
@@ -7,6 +7,7 @@ import { PaymentMethodComponent } from '../../components/payment-method/payment-
 
 import { AlertService } from '../../services/alert.service';
 import { SubscriptionService } from '../../services/subscription.service';
+import { AuthService } from '../../services/auth.service';
 
 import { Card } from '../../models/card';
 import { SubscriptionBillingFrequency } from '../../models/enums/subscription-billing-frequency';
@@ -32,13 +33,14 @@ export class PaymentComponent implements OnInit {
     private alertService: AlertService,
     private route: ActivatedRoute,
     private router: Router,
-    private subscriptionService: SubscriptionService
+    private subscriptionService: SubscriptionService,
+    private authService: AuthService
   ) {
     this.handlePayment = this.handlePayment.bind(this);
   }
 
   ngOnInit(): void {
-    this.isLoggedIn = !!localStorage.getItem('token');
+    this.isLoggedIn = this.authService.isAuthenticated();
 
     this.route.queryParams.subscribe((params) => {
       this.referrer = params['referrer'] || '/';

--- a/Frontend.Angular/src/app/pages/premium-subscription/premium-subscription.component.ts
+++ b/Frontend.Angular/src/app/pages/premium-subscription/premium-subscription.component.ts
@@ -10,6 +10,7 @@ import { AlertService } from '../../services/alert.service';
 import { ConfigService } from '../../services/config.service';
 import { PaymentService } from '../../services/payment.service';
 import { SubscriptionService } from '../../services/subscription.service';
+import { AuthService } from '../../services/auth.service';
 
 import { Card } from '../../models/card';
 import { SubscriptionBillingFrequency } from '../../models/enums/subscription-billing-frequency';
@@ -51,11 +52,12 @@ export class PremiumSubscriptionComponent implements OnInit {
     private router: Router,
     private paymentService: PaymentService,
     private subscriptionService: SubscriptionService,
-    private configService: ConfigService
+    private configService: ConfigService,
+    private authService: AuthService
   ) {}
 
   ngOnInit(): void {
-    this.isLoggedIn = !!localStorage.getItem('token');
+    this.isLoggedIn = this.authService.isAuthenticated();
     this.stripePromise = loadStripe(this.configService.get('stripePublishableKey'));
   }
 

--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -28,6 +28,7 @@ export class AuthService implements OnDestroy {
     private refreshTimerSub: Subscription | null = null;
     private profileSubject = new BehaviorSubject<UserProfile | null>(null);
     profile$ = this.profileSubject.asObservable();
+    private memoryStorage = new Map<string, string>();
 
     constructor(
         private http: HttpClient,
@@ -76,7 +77,7 @@ export class AuthService implements OnDestroy {
     }
 
     getAccessToken(): string | null {
-        return this.accessToken || localStorage.getItem('access_token');
+        return this.accessToken || this.getStorage(this.ACCESS_TOKEN_KEY);
     }
 
     refreshToken(): Observable<TokenResponse> {
@@ -159,7 +160,7 @@ export class AuthService implements OnDestroy {
                 this.profileSubject.next(profile);
                 if (profile.exp) this.scheduleRefresh(profile.exp);
             } catch {
-                localStorage.removeItem(this.PROFILE_KEY);
+                this.removeStorage(this.PROFILE_KEY);
             }
         }
     }
@@ -223,11 +224,21 @@ export class AuthService implements OnDestroy {
     }
 
     private getStorage(key: string): string | null {
-        return localStorage.getItem(key);
+        const inMemory = this.memoryStorage.get(key);
+        if (inMemory !== undefined) return inMemory;
+        const sessionValue = sessionStorage.getItem(key);
+        if (sessionValue) this.memoryStorage.set(key, sessionValue);
+        return sessionValue;
     }
 
     private setStorage(key: string, value: string): void {
-        localStorage.setItem(key, value);
+        this.memoryStorage.set(key, value);
+        sessionStorage.setItem(key, value);
+    }
+
+    private removeStorage(key: string): void {
+        this.memoryStorage.delete(key);
+        sessionStorage.removeItem(key);
     }
 
     private clearSession() {
@@ -238,7 +249,7 @@ export class AuthService implements OnDestroy {
             this.REFRESH_TOKEN_KEY,
             this.REFRESH_EXPIRY_KEY,
             this.ACCESS_TOKEN_KEY // ✅ clear persisted token
-        ].forEach(k => localStorage.removeItem(k));
+        ].forEach(k => this.removeStorage(k));
         this.cancelRefresh();
         this.notificationService.stopConnection();
     }


### PR DESCRIPTION
## Summary
- Use in-memory map with sessionStorage fallback for auth tokens
- Add helper to remove persisted keys and wire through clearSession
- Check auth status via AuthService instead of localStorage in payment-related components

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689ced016034832785898466647f0572