### PR TITLE
feat: hash refresh tokens and track per device

### DIFF
--- a/api/Avancira.Infrastructure/Identity/Tokens/RefreshToken.cs
+++ b/api/Avancira.Infrastructure/Identity/Tokens/RefreshToken.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Avancira.Infrastructure.Identity.Tokens;
+
+public class RefreshToken
+{
+    public Guid Id { get; set; }
+    public string UserId { get; set; } = default!;
+    public string TokenHash { get; set; } = default!;
+    public string Device { get; set; } = default!;
+    public DateTime Expiry { get; set; }
+}

--- a/api/Avancira.Infrastructure/Persistence/AvanciraDbContext.cs
+++ b/api/Avancira.Infrastructure/Persistence/AvanciraDbContext.cs
@@ -18,6 +18,7 @@ using Avancira.Domain.Subscription;
 using Avancira.Infrastructure.Catalog;
 using Avancira.Domain.Lessons;
 using Avancira.Domain.Notifications;
+using Avancira.Infrastructure.Identity.Tokens;
 
 namespace Avancira.Infrastructure.Persistence;
 public class AvanciraDbContext : IdentityDbContext<
@@ -61,6 +62,7 @@ public class AvanciraDbContext : IdentityDbContext<
     public DbSet<Transaction> Transactions { get; set; }
     public DbSet<Wallet> Wallets { get; set; }
     public DbSet<WalletLog> WalletLogs { get; set; }
+    public DbSet<RefreshToken> RefreshTokens { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/api/Avancira.Infrastructure/Persistence/Configurations/RefreshTokenConfiguration.cs
+++ b/api/Avancira.Infrastructure/Persistence/Configurations/RefreshTokenConfiguration.cs
@@ -1,0 +1,17 @@
+using Avancira.Infrastructure.Identity.Tokens;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Avancira.Infrastructure.Persistence.Configurations;
+
+public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
+{
+    public void Configure(EntityTypeBuilder<RefreshToken> builder)
+    {
+        builder.ToTable("RefreshTokens");
+        builder.HasKey(t => t.Id);
+        builder.HasIndex(t => new { t.UserId, t.Device }).IsUnique();
+        builder.Property(t => t.TokenHash).IsRequired();
+        builder.Property(t => t.Device).HasMaxLength(200);
+    }
+}


### PR DESCRIPTION
## Summary
- hash refresh tokens before storing
- persist hashed refresh tokens per user/device
- validate refresh tokens against hashes and replace on use

## Testing
- `dotnet build Avancira.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689cf3b80ad483279af43bc690e51d6d