### PR TITLE
Add device identifier to JWT claims

### DIFF
--- a/api/Avancira.API/Controllers/AuthController.cs
+++ b/api/Avancira.API/Controllers/AuthController.cs
@@ -23,7 +23,7 @@ public class AuthController : BaseApiController
     [SwaggerOperation(OperationId = "GenerateToken")]
     public async Task<ActionResult<TokenResponse>> GenerateToken([FromBody] TokenGenerationDto request, CancellationToken cancellationToken)
     {
-        string deviceId = HttpContext.GetOrCreateDeviceId();
+        string deviceId = HttpContext.GetDeviceIdentifier();
         string ip = HttpContext.GetIpAddress();
 
         var result = await _tokenService.GenerateTokenAsync(request, deviceId, ip, cancellationToken);
@@ -42,7 +42,7 @@ public class AuthController : BaseApiController
     [SwaggerOperation(OperationId = "RefreshToken")]
     public async Task<ActionResult<TokenResponse>> RefreshToken([FromBody] RefreshTokenDto request, CancellationToken cancellationToken)
     {
-        string deviceId = HttpContext.GetOrCreateDeviceId();
+        string deviceId = HttpContext.GetDeviceIdentifier();
         string ip = HttpContext.GetIpAddress();
 
         var result = await _tokenService.RefreshTokenAsync(request, deviceId, ip, cancellationToken);

--- a/api/Avancira.Infrastructure/Common/Extensions/HttpContextExtensions.cs
+++ b/api/Avancira.Infrastructure/Common/Extensions/HttpContextExtensions.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.AspNetCore.Http;
-using System.Security.Cryptography;
-using System.Text;
 
 namespace Avancira.Infrastructure.Common.Extensions;
 
@@ -20,7 +18,7 @@ public static class HttpContextExtensions
         return ip;
     }
 
-    public static string GetOrCreateDeviceId(this HttpContext context)
+    public static string GetDeviceIdentifier(this HttpContext context)
     {
         var deviceId = context.Request.Headers["Device-Id"].FirstOrDefault();
 

--- a/api/Avancira.Infrastructure/Identity/Tokens/TokenService.cs
+++ b/api/Avancira.Infrastructure/Identity/Tokens/TokenService.cs
@@ -80,7 +80,7 @@ public sealed class TokenService : ITokenService
 
     private async Task<TokenResponse> GenerateTokens(User user, string deviceId, string ipAddress)
     {
-        string token = await GenerateJwt(user, ipAddress);
+        string token = await GenerateJwt(user, deviceId, ipAddress);
 
         var refreshToken = GenerateRefreshToken();
         var refreshTokenHash = HashToken(refreshToken);
@@ -120,8 +120,8 @@ public sealed class TokenService : ITokenService
         return new TokenResponse(token, refreshToken, refreshTokenExpiryTime);
     }
 
-    private async Task<string> GenerateJwt(User user, string ipAddress) =>
-        GenerateEncryptedToken(GetSigningCredentials(), await GetClaimsAsync(user, ipAddress));
+    private async Task<string> GenerateJwt(User user, string deviceId, string ipAddress) =>
+        GenerateEncryptedToken(GetSigningCredentials(), await GetClaimsAsync(user, deviceId, ipAddress));
 
     private SigningCredentials GetSigningCredentials()
     {
@@ -142,7 +142,7 @@ public sealed class TokenService : ITokenService
         return tokenHandler.WriteToken(token);
     }
 
-    private async Task<List<Claim>> GetClaimsAsync(User user, string ipAddress)
+    private async Task<List<Claim>> GetClaimsAsync(User user, string deviceId, string ipAddress)
     {
         var claims = new List<Claim>
         {
@@ -155,6 +155,7 @@ public sealed class TokenService : ITokenService
             new(ClaimTypes.Surname, user.LastName ?? string.Empty),
             new(AvanciraClaims.TimeZoneId, user.TimeZoneId ?? string.Empty),
             new(AvanciraClaims.IpAddress, ipAddress),
+            new(AvanciraClaims.DeviceId, deviceId),
             new(AvanciraClaims.ImageUrl, user.ImageUrl == null ? string.Empty : user.ImageUrl.ToString())
         };
 

--- a/api/Avancira.Shared/Authorization/AvanciraClaims.cs
+++ b/api/Avancira.Shared/Authorization/AvanciraClaims.cs
@@ -5,6 +5,7 @@ public static class AvanciraClaims
     public const string Permission = "permission";
     public const string ImageUrl = "image_url";
     public const string IpAddress = "ipAddress";
+    public const string DeviceId = "device_id";
     public const string TimeZoneId = "timeZoneId";
     public const string Expiration = "exp";
 }


### PR DESCRIPTION
## Summary
- add `DeviceId` claim constant
- include device identifier in JWT generation and refresh
- use `GetDeviceIdentifier` extension in auth endpoints

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f4f0123788327bde6e3bfaee66c44