### PR TITLE
Capture user agent and OS for refresh tokens

### DIFF
--- a/api/Avancira.API/Controllers/AuthController.cs
+++ b/api/Avancira.API/Controllers/AuthController.cs
@@ -25,8 +25,10 @@ public class AuthController : BaseApiController
     {
         string deviceId = HttpContext.GetDeviceIdentifier();
         string ip = HttpContext.GetIpAddress();
+        string userAgent = HttpContext.GetUserAgent();
+        string operatingSystem = HttpContext.GetOperatingSystem();
 
-        var result = await _tokenService.GenerateTokenAsync(request, deviceId, ip, cancellationToken);
+        var result = await _tokenService.GenerateTokenAsync(request, deviceId, ip, userAgent, operatingSystem, cancellationToken);
 
         if (result != null)
         {
@@ -44,8 +46,10 @@ public class AuthController : BaseApiController
     {
         string deviceId = HttpContext.GetDeviceIdentifier();
         string ip = HttpContext.GetIpAddress();
+        string userAgent = HttpContext.GetUserAgent();
+        string operatingSystem = HttpContext.GetOperatingSystem();
 
-        var result = await _tokenService.RefreshTokenAsync(request, deviceId, ip, cancellationToken);
+        var result = await _tokenService.RefreshTokenAsync(request, deviceId, ip, userAgent, operatingSystem, cancellationToken);
 
         return Ok(result);
     }

--- a/api/Avancira.Application/Identity/Tokens/ITokenService.cs
+++ b/api/Avancira.Application/Identity/Tokens/ITokenService.cs
@@ -3,7 +3,7 @@
 namespace Avancira.Application.Identity.Tokens;
 public interface ITokenService
 {
-    Task<TokenResponse> GenerateTokenAsync(TokenGenerationDto request, string deviceId, string ipAddress, CancellationToken cancellationToken);
-    Task<TokenResponse> RefreshTokenAsync(RefreshTokenDto request, string deviceId, string ipAddress, CancellationToken cancellationToken);
+    Task<TokenResponse> GenerateTokenAsync(TokenGenerationDto request, string deviceId, string ipAddress, string userAgent, string operatingSystem, CancellationToken cancellationToken);
+    Task<TokenResponse> RefreshTokenAsync(RefreshTokenDto request, string deviceId, string ipAddress, string userAgent, string operatingSystem, CancellationToken cancellationToken);
 
 }

--- a/api/Avancira.Infrastructure/Common/Extensions/HttpContextExtensions.cs
+++ b/api/Avancira.Infrastructure/Common/Extensions/HttpContextExtensions.cs
@@ -29,4 +29,20 @@ public static class HttpContextExtensions
 
         return deviceId;
     }
+
+    public static string GetUserAgent(this HttpContext context) =>
+        context.Request.Headers["User-Agent"].FirstOrDefault() ?? "N/A";
+
+    public static string GetOperatingSystem(this HttpContext context)
+    {
+        var userAgent = context.GetUserAgent();
+
+        if (userAgent.Contains("Windows", StringComparison.OrdinalIgnoreCase)) return "Windows";
+        if (userAgent.Contains("Android", StringComparison.OrdinalIgnoreCase)) return "Android";
+        if (userAgent.Contains("iPhone", StringComparison.OrdinalIgnoreCase) || userAgent.Contains("iPad", StringComparison.OrdinalIgnoreCase)) return "iOS";
+        if (userAgent.Contains("Mac OS", StringComparison.OrdinalIgnoreCase) || userAgent.Contains("Macintosh", StringComparison.OrdinalIgnoreCase)) return "macOS";
+        if (userAgent.Contains("Linux", StringComparison.OrdinalIgnoreCase)) return "Linux";
+
+        return "Unknown";
+    }
 }

--- a/api/Avancira.Infrastructure/Identity/Tokens/RefreshToken.cs
+++ b/api/Avancira.Infrastructure/Identity/Tokens/RefreshToken.cs
@@ -8,7 +8,7 @@ public class RefreshToken
     public string UserId { get; set; } = default!;
     public string TokenHash { get; set; } = default!;
     public string Device { get; set; } = default!;
-    public string? Browser { get; set; }
+    public string? UserAgent { get; set; }
     public string? OperatingSystem { get; set; }
     public string IpAddress { get; set; } = default!;
     public string? Country { get; set; }

--- a/api/Avancira.Infrastructure/Persistence/Configurations/RefreshTokenConfiguration.cs
+++ b/api/Avancira.Infrastructure/Persistence/Configurations/RefreshTokenConfiguration.cs
@@ -15,7 +15,7 @@ public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
 
         builder.Property(t => t.TokenHash).IsRequired();
         builder.Property(t => t.Device).IsRequired().HasMaxLength(200);
-        builder.Property(t => t.Browser).HasMaxLength(100);
+        builder.Property(t => t.UserAgent).HasMaxLength(100);
         builder.Property(t => t.OperatingSystem).HasMaxLength(100);
         builder.Property(t => t.IpAddress).IsRequired().HasMaxLength(45);
         builder.Property(t => t.Country).HasMaxLength(100);
@@ -26,7 +26,7 @@ public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
         builder.Property(t => t.RevokedAt);
 
         builder.HasIndex(t => t.Device);
-        builder.HasIndex(t => t.Browser);
+        builder.HasIndex(t => t.UserAgent);
         builder.HasIndex(t => t.OperatingSystem);
         builder.HasIndex(t => t.IpAddress);
         builder.HasIndex(t => t.CreatedAt);

--- a/api/Avancira.Migrations/Migrations/20250701160000_RenameBrowserToUserAgent.cs
+++ b/api/Avancira.Migrations/Migrations/20250701160000_RenameBrowserToUserAgent.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Avancira.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class RenameBrowserToUserAgent : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "Browser",
+                table: "RefreshTokens",
+                newName: "UserAgent");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_RefreshTokens_Browser",
+                table: "RefreshTokens",
+                newName: "IX_RefreshTokens_UserAgent");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameIndex(
+                name: "IX_RefreshTokens_UserAgent",
+                table: "RefreshTokens",
+                newName: "IX_RefreshTokens_Browser");
+
+            migrationBuilder.RenameColumn(
+                name: "UserAgent",
+                table: "RefreshTokens",
+                newName: "Browser");
+        }
+    }
+}

--- a/api/Avancira.Migrations/Migrations/AvanciraDbContextModelSnapshot.cs
+++ b/api/Avancira.Migrations/Migrations/AvanciraDbContextModelSnapshot.cs
@@ -93,7 +93,7 @@ namespace Avancira.Migrations.Migrations
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
 
-                    b.Property<string>("Browser")
+                    b.Property<string>("UserAgent")
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)");
 
@@ -137,7 +137,7 @@ namespace Avancira.Migrations.Migrations
 
                     b.HasIndex("Device");
 
-                    b.HasIndex("Browser");
+                    b.HasIndex("UserAgent");
 
                     b.HasIndex("OperatingSystem");
 


### PR DESCRIPTION
## Summary
- rename refresh token Browser field to UserAgent
- store OperatingSystem when issuing refresh tokens
- expose helpers to read User-Agent and Operating System from requests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f5c0b124c8327b3de04135346d23e