### PR TITLE
Add scheduled refresh token cleanup job

### DIFF
--- a/api/Avancira.API/appsettings.json
+++ b/api/Avancira.API/appsettings.json
@@ -19,6 +19,10 @@
     "TokenExpirationInMinutes": 10,
     "RefreshTokenExpirationInDays": 7
   },
+  "TokenCleanupOptions": {
+    "RetentionDays": 0,
+    "Schedule": "0 0 * * *"
+  },
   "MailOptions": {
     "From": "mukesh@fullstackhero.net",
     "Host": "smtp.ethereal.email",

--- a/api/Avancira.Infrastructure/Extensions.cs
+++ b/api/Avancira.Infrastructure/Extensions.cs
@@ -9,6 +9,7 @@ using Avancira.Infrastructure.Catalog;
 using Avancira.Infrastructure.Cors;
 using Avancira.Infrastructure.Exceptions;
 using Avancira.Infrastructure.Identity;
+using Avancira.Infrastructure.Identity.Tokens;
 using Avancira.Infrastructure.Jobs;
 using Avancira.Infrastructure.Logging.Serilog;
 using Avancira.Infrastructure.Mail;
@@ -67,6 +68,7 @@ public static class Extensions
         builder.Services.Configure<JitsiOptions>(builder.Configuration.GetSection("Avancira:Jitsi"));
         builder.Services.Configure<GoogleOptions>(builder.Configuration.GetSection("Avancira:ExternalServices:Google"));
         builder.Services.Configure<FacebookOptions>(builder.Configuration.GetSection("Avancira:ExternalServices:Facebook"));
+        builder.Services.Configure<TokenCleanupOptions>(builder.Configuration.GetSection(nameof(TokenCleanupOptions)));
 
 
         // Configure Mappings

--- a/api/Avancira.Infrastructure/Identity/Extensions.cs
+++ b/api/Avancira.Infrastructure/Identity/Extensions.cs
@@ -24,6 +24,7 @@ internal static class Extensions
         services.AddScoped<CurrentUserMiddleware>();
         services.AddScoped<ICurrentUser, CurrentUser>();
         services.AddScoped<ITokenService, TokenService>();
+        services.AddTransient<TokenCleanupService>();
         services.AddScoped(sp => (ICurrentUserInitializer)sp.GetRequiredService<ICurrentUser>());
         services.AddTransient<Avancira.Application.Identity.Users.Abstractions.IUserService, UserService>();
         services.AddTransient<IRoleService, RoleService>();

--- a/api/Avancira.Infrastructure/Identity/Tokens/TokenCleanupOptions.cs
+++ b/api/Avancira.Infrastructure/Identity/Tokens/TokenCleanupOptions.cs
@@ -1,0 +1,10 @@
+using Hangfire;
+
+namespace Avancira.Infrastructure.Identity.Tokens;
+
+public class TokenCleanupOptions
+{
+    public int RetentionDays { get; set; } = 0;
+    public string Schedule { get; set; } = Cron.Daily();
+}
+

--- a/api/Avancira.Infrastructure/Identity/Tokens/TokenCleanupService.cs
+++ b/api/Avancira.Infrastructure/Identity/Tokens/TokenCleanupService.cs
@@ -1,0 +1,44 @@
+using Avancira.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Avancira.Infrastructure.Identity.Tokens;
+
+public class TokenCleanupService
+{
+    private readonly AvanciraDbContext _dbContext;
+    private readonly TokenCleanupOptions _options;
+    private readonly ILogger<TokenCleanupService> _logger;
+
+    public TokenCleanupService(
+        AvanciraDbContext dbContext,
+        IOptions<TokenCleanupOptions> options,
+        ILogger<TokenCleanupService> logger)
+    {
+        _dbContext = dbContext;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task CleanupAsync()
+    {
+        var now = DateTime.UtcNow;
+        var threshold = now.AddDays(-_options.RetentionDays);
+
+        var tokens = await _dbContext.RefreshTokens
+            .Where(t => (t.Revoked && t.RevokedAt <= threshold) || t.ExpiresAt <= threshold)
+            .ToListAsync();
+
+        if (tokens.Count == 0)
+        {
+            return;
+        }
+
+        _dbContext.RefreshTokens.RemoveRange(tokens);
+        await _dbContext.SaveChangesAsync();
+
+        _logger.LogInformation("Removed {Count} expired or revoked refresh tokens", tokens.Count);
+    }
+}
+

--- a/api/Avancira.Infrastructure/Jobs/RecurringJobsService.cs
+++ b/api/Avancira.Infrastructure/Jobs/RecurringJobsService.cs
@@ -1,6 +1,7 @@
 using Avancira.Application.Jobs;
+using Avancira.Infrastructure.Identity.Tokens;
 using Hangfire;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -8,12 +9,12 @@ namespace Avancira.Infrastructure.Jobs;
 
 public class RecurringJobsService : IHostedService
 {
-    private readonly IServiceProvider _serviceProvider;
+    private readonly IConfiguration _configuration;
     private readonly ILogger<RecurringJobsService> _logger;
 
-    public RecurringJobsService(IServiceProvider serviceProvider, ILogger<RecurringJobsService> logger)
+    public RecurringJobsService(IConfiguration configuration, ILogger<RecurringJobsService> logger)
     {
-        _serviceProvider = serviceProvider;
+        _configuration = configuration;
         _logger = logger;
     }
 
@@ -23,6 +24,13 @@ public class RecurringJobsService : IHostedService
 
         try
         {
+            var cleanupOptions = _configuration.GetSection(nameof(TokenCleanupOptions)).Get<TokenCleanupOptions>() ?? new TokenCleanupOptions();
+
+            RecurringJob.AddOrUpdate<TokenCleanupService>(
+                "refresh-token-cleanup",
+                service => service.CleanupAsync(),
+                cleanupOptions.Schedule);
+
             // Set up your payment processing recurring jobs
             
             // Monthly payment processing - 1st day of each month at 00:00 UTC


### PR DESCRIPTION
## Summary
- add service to purge revoked or expired refresh tokens
- schedule recurring job via Hangfire
- document token cleanup retention and schedule in appsettings

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f9300bd708327b362e2aaaf8650bb