### PR TITLE
Persist device ID from tokens and reuse across requests

### DIFF
--- a/Frontend.Angular/src/app/models/UserProfile.ts
+++ b/Frontend.Angular/src/app/models/UserProfile.ts
@@ -7,6 +7,7 @@ export interface UserProfile {
   timeZoneId?: string;
   ipAddress?: string;
   imageUrl?: string;
+  deviceId?: string;
   roles: string[];        // multiple roles
   permissions: string[];  // permissions as strings
   exp?: number;           // token expiration (epoch seconds)

--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -283,6 +283,11 @@ export class AuthService implements OnDestroy {
 
   private decodeToken(token: string): UserProfile {
     const decoded: any = jwtDecode(token);
+    // Persist device id if present in the token
+    if (decoded?.device_id) {
+      localStorage.setItem('deviceId', decoded.device_id);
+    }
+
     return {
       id: decoded.sub,
       email: decoded.email,
@@ -294,6 +299,7 @@ export class AuthService implements OnDestroy {
       timeZoneId: decoded.timeZoneId,
       ipAddress: decoded.ipAddress,
       imageUrl: decoded.image_url,
+      deviceId: decoded.device_id,
       roles: this.toArray(decoded.role),
       permissions: this.toArray(decoded.permissions),
       exp: decoded.exp

--- a/admin/Infrastructure/Auth/Jwt/JwtAuthenticationHeaderHandler.cs
+++ b/admin/Infrastructure/Auth/Jwt/JwtAuthenticationHeaderHandler.cs
@@ -1,27 +1,56 @@
-﻿using Microsoft.AspNetCore.Components;
+using System.Text.Json;
+using Avancira.Admin.Infrastructure.Storage;
+using Avancira.Shared.Authorization;
+using Blazored.LocalStorage;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication.Internal;
 using System.Net.Http.Headers;
 
 namespace Avancira.Admin.Infrastructure.Auth.Jwt;
+
 public class JwtAuthenticationHeaderHandler : DelegatingHandler
 {
     private readonly IAccessTokenProviderAccessor _tokenProviderAccessor;
     private readonly NavigationManager _navigation;
+    private readonly ILocalStorageService _localStorage;
 
-    public JwtAuthenticationHeaderHandler(IAccessTokenProviderAccessor tokenProviderAccessor, NavigationManager navigation)
+    public JwtAuthenticationHeaderHandler(
+        IAccessTokenProviderAccessor tokenProviderAccessor,
+        NavigationManager navigation,
+        ILocalStorageService localStorage)
     {
         _tokenProviderAccessor = tokenProviderAccessor;
         _navigation = navigation;
+        _localStorage = localStorage;
     }
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        // skip token endpoints
+        string? deviceId = await _localStorage.GetItemAsync<string>(StorageConstants.Local.DeviceId);
+
         if (request.RequestUri?.AbsolutePath.Contains("/auth") != true)
         {
             if (await _tokenProviderAccessor.TokenProvider.GetAccessTokenAsync() is string token)
             {
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+                try
+                {
+                    string payload = token.Split('.')[1];
+                    byte[] jsonBytes = ParseBase64WithoutPadding(payload);
+                    var keyValuePairs = JsonSerializer.Deserialize<Dictionary<string, object>>(jsonBytes);
+                    if (keyValuePairs != null &&
+                        keyValuePairs.TryGetValue(AvanciraClaims.DeviceId, out var claim) &&
+                        claim is not null)
+                    {
+                        deviceId = claim.ToString();
+                        await _localStorage.SetItemAsync(StorageConstants.Local.DeviceId, deviceId);
+                    }
+                }
+                catch
+                {
+                    // ignore decoding errors
+                }
             }
             else
             {
@@ -29,6 +58,22 @@ public class JwtAuthenticationHeaderHandler : DelegatingHandler
             }
         }
 
+        if (string.IsNullOrEmpty(deviceId))
+        {
+            deviceId = Guid.NewGuid().ToString();
+            await _localStorage.SetItemAsync(StorageConstants.Local.DeviceId, deviceId);
+        }
+
+        request.Headers.TryAddWithoutValidation("Device-Id", deviceId);
+
         return await base.SendAsync(request, cancellationToken);
     }
+
+    private static byte[] ParseBase64WithoutPadding(string payload)
+    {
+        payload = payload.Trim().Replace('-', '+').Replace('_', '/');
+        string base64 = payload.PadRight(payload.Length + (4 - payload.Length % 4) % 4, '=');
+        return Convert.FromBase64String(base64);
+    }
 }
+

--- a/admin/Infrastructure/Storage/StorageConstants.cs
+++ b/admin/Infrastructure/Storage/StorageConstants.cs
@@ -9,5 +9,6 @@ public static class StorageConstants
         public static string RefreshToken = "refreshToken";
         public static string ImageUri = "userImageURL";
         public static string Permissions = "permissions";
+        public static string DeviceId = "deviceId";
     }
 }


### PR DESCRIPTION
## Summary
- store `device_id` from JWTs in localStorage and user profile
- send stored `Device-Id` header and replace it when tokens include a new claim
- persist device id from access tokens in admin client

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f9e23a250832793b5c721bff53c7d