### PR TITLE
Implement refresh token cookies and in-memory JWT handling

### DIFF
--- a/api/Avancira.Application/Identity/Tokens/Dtos/RefreshTokenDto.cs
+++ b/api/Avancira.Application/Identity/Tokens/Dtos/RefreshTokenDto.cs
@@ -1,2 +1,8 @@
-﻿namespace Avancira.Application.Identity.Tokens.Dtos;
-public record RefreshTokenDto(string Token, string RefreshToken);
+namespace Avancira.Application.Identity.Tokens.Dtos;
+
+/// <summary>
+/// Request payload for refreshing an access token. Only the (potentially expired)
+/// access token is sent by the client. The refresh token is supplied via a
+/// secure HttpOnly cookie.
+/// </summary>
+public record RefreshTokenDto(string? Token);

--- a/api/Avancira.Application/Identity/Tokens/Dtos/RevokeTokenDto.cs
+++ b/api/Avancira.Application/Identity/Tokens/Dtos/RevokeTokenDto.cs
@@ -1,4 +1,0 @@
-namespace Avancira.Application.Identity.Tokens.Dtos;
-
-public record RevokeTokenDto(string RefreshToken);
-

--- a/api/Avancira.Application/Identity/Tokens/Dtos/TokenPair.cs
+++ b/api/Avancira.Application/Identity/Tokens/Dtos/TokenPair.cs
@@ -1,0 +1,8 @@
+namespace Avancira.Application.Identity.Tokens.Dtos;
+
+/// <summary>
+/// Internal DTO representing both access and refresh tokens.
+/// The refresh token is never returned to the client but is used by the
+/// API to manage the HttpOnly cookie.
+/// </summary>
+public record TokenPair(string Token, string RefreshToken, DateTime RefreshTokenExpiryTime);

--- a/api/Avancira.Application/Identity/Tokens/Dtos/TokenResponse.cs
+++ b/api/Avancira.Application/Identity/Tokens/Dtos/TokenResponse.cs
@@ -1,3 +1,7 @@
-﻿namespace Avancira.Application.Identity.Tokens.Dtos;
-public record TokenResponse(string Token, string RefreshToken, DateTime RefreshTokenExpiryTime);
+namespace Avancira.Application.Identity.Tokens.Dtos;
 
+/// <summary>
+/// Response returned to the client after authentication or token refresh.
+/// Contains only the short-lived access token.
+/// </summary>
+public record TokenResponse(string Token);

--- a/api/Avancira.Application/Identity/Tokens/ITokenService.cs
+++ b/api/Avancira.Application/Identity/Tokens/ITokenService.cs
@@ -1,11 +1,10 @@
-﻿using Avancira.Application.Identity.Tokens.Dtos;
+using Avancira.Application.Identity.Tokens.Dtos;
 
 namespace Avancira.Application.Identity.Tokens;
+
 public interface ITokenService
 {
-    Task<TokenResponse> GenerateTokenAsync(TokenGenerationDto request, string deviceId, string ipAddress, string userAgent, string operatingSystem, CancellationToken cancellationToken);
-    Task<TokenResponse> RefreshTokenAsync(RefreshTokenDto request, string deviceId, string ipAddress, string userAgent, string operatingSystem, CancellationToken cancellationToken);
-
-    Task RevokeTokenAsync(RevokeTokenDto request, string userId, string deviceId, CancellationToken cancellationToken);
-
+    Task<TokenPair> GenerateTokenAsync(TokenGenerationDto request, string deviceId, string ipAddress, string userAgent, string operatingSystem, CancellationToken cancellationToken);
+    Task<TokenPair> RefreshTokenAsync(string? token, string refreshToken, string deviceId, string ipAddress, string userAgent, string operatingSystem, CancellationToken cancellationToken);
+    Task RevokeTokenAsync(string refreshToken, string userId, string deviceId, CancellationToken cancellationToken);
 }

--- a/api/Avancira.Application/Identity/Tokens/Validators/RefreshTokenValidator.cs
+++ b/api/Avancira.Application/Identity/Tokens/Validators/RefreshTokenValidator.cs
@@ -1,13 +1,12 @@
-﻿using Avancira.Application.Identity.Tokens.Dtos;
+using Avancira.Application.Identity.Tokens.Dtos;
 using FluentValidation;
 
 namespace Avancira.Application.Identity.Tokens.Validators;
+
 public class RefreshTokenValidator : AbstractValidator<RefreshTokenDto>
 {
     public RefreshTokenValidator()
     {
         RuleFor(p => p.Token).Cascade(CascadeMode.Stop).NotEmpty();
-
-        RuleFor(p => p.RefreshToken).Cascade(CascadeMode.Stop).NotEmpty();
     }
 }


### PR DESCRIPTION
## Summary
- Return only short-lived access tokens in auth responses and store refresh tokens in HttpOnly cookies
- Rotate refresh tokens server-side and revoke via cookie-aware endpoints
- Simplify refresh requests to supply only expired access token in body

## Testing
- `dotnet build Avancira.API/Avancira.API.csproj` *(failed: command not found)*
- `apt-get update` *(failed: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689fb185011c832791999ffa9fbbd7e6