### PR TITLE
Handle refresh failures without automatic logout

### DIFF
--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -134,10 +134,7 @@ export class AuthService implements OnDestroy {
             this.applyTokens(res);
           }
         }),
-        catchError((err) => {
-          this.logout();
-          return this.handleError(err);
-        })
+        catchError((err) => this.handleError(err))
       );
   }
 
@@ -192,7 +189,10 @@ export class AuthService implements OnDestroy {
       .pipe(take(1))
       .subscribe({
         next: (r) => this.endRefresh(r.token),
-        error: (e) => this.refreshFailed(e)
+        error: (e) => {
+          this.refreshFailed(e);
+          this.logout();
+        }
       });
   }
 
@@ -219,7 +219,10 @@ export class AuthService implements OnDestroy {
         .pipe(take(1))
         .subscribe({
           next: (r) => this.endRefresh(r.token),
-          error: (e) => this.refreshFailed(e)
+          error: (e) => {
+            this.refreshFailed(e);
+            this.logout();
+          }
         });
     });
   }


### PR DESCRIPTION
## Summary
- Avoid logging out inside `refreshToken` so callers manage failure behavior
- Log out in `restoreProfile` and scheduled refresh when a token refresh error occurs

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Module not found and stylesheet import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a074e1aca083279fa2b2ccc6192ad1