### PR TITLE
feat(auth): allow skipping auth interceptor

### DIFF
--- a/Frontend.Angular/src/app/interceptors/auth.interceptor.spec.ts
+++ b/Frontend.Angular/src/app/interceptors/auth.interceptor.spec.ts
@@ -1,9 +1,15 @@
-import { HttpClient, HttpErrorResponse, provideHttpClient, withInterceptors } from '@angular/common/http';
+import {
+  HttpClient,
+  HttpContext,
+  HttpErrorResponse,
+  provideHttpClient,
+  withInterceptors
+} from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 
-import { authInterceptor } from './auth.interceptor';
+import { SKIP_AUTH, authInterceptor } from './auth.interceptor';
 import { AuthService } from '../services/auth.service';
 import { NotificationService } from '../services/notification.service';
 import { environment } from '../environments/environment';
@@ -60,7 +66,8 @@ describe('authInterceptor', () => {
     const refreshSpy = spyOn(authService, 'refreshToken');
     let error: HttpErrorResponse | undefined;
 
-    http.post('/auth/token', {}).subscribe({ error: e => error = e });
+    const context = new HttpContext().set(SKIP_AUTH, true);
+    http.post('/auth/token', {}, { context }).subscribe({ error: e => error = e });
 
     const req = httpMock.expectOne('/auth/token');
     req.flush('Unauthorized', { status: 401, statusText: 'Unauthorized' });

--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient, HttpContext, HttpErrorResponse } from '@angular/common/http';
 import { Injectable, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import {
@@ -21,6 +21,7 @@ import { jwtDecode } from 'jwt-decode';
 import { NotificationService } from './notification.service';
 
 import { environment } from '../environments/environment';
+import { SKIP_AUTH } from '../interceptors/auth.interceptor';
 import { UserProfile } from '../models/UserProfile';
 
 export interface TokenResponse {
@@ -82,7 +83,11 @@ export class AuthService implements OnDestroy {
 
   login(email: string, password: string): Observable<UserProfile> {
     return this.http
-      .post<TokenResponse>(`${this.apiBase}/auth/token`, { email, password })
+      .post<TokenResponse>(
+        `${this.apiBase}/auth/token`,
+        { email, password },
+        { context: new HttpContext().set(SKIP_AUTH, true) }
+      )
       .pipe(
         switchMap((res) => {
           if (!res?.token) {
@@ -127,7 +132,11 @@ export class AuthService implements OnDestroy {
 
   refreshToken(): Observable<TokenResponse> {
     return this.http
-      .post<TokenResponse>(`${this.apiBase}/auth/refresh`, {}, { withCredentials: true })
+      .post<TokenResponse>(
+        `${this.apiBase}/auth/refresh`,
+        {},
+        { withCredentials: true, context: new HttpContext().set(SKIP_AUTH, true) }
+      )
       .pipe(
         tap((res) => {
           if (res?.token) {


### PR DESCRIPTION
## Summary
- use HttpContextToken to mark requests that should bypass auth handling
- add SKIP_AUTH context to login and refresh token requests
- adjust auth interceptor tests for context token

## Testing
- `npm test` *(fails: export 'DiplomaStatus' etc. not found and missing styles)*

------
https://chatgpt.com/codex/tasks/task_e_68a076eb96f483279d53c0eb2ff6156f