### PR TITLE
Specify refresh token cookie path

### DIFF
--- a/api/Avancira.API/Controllers/AuthController.cs
+++ b/api/Avancira.API/Controllers/AuthController.cs
@@ -75,7 +75,10 @@ public class AuthController : BaseApiController
             await _tokenService.RevokeTokenAsync(refreshToken, userId, deviceId, cancellationToken);
         }
 
-        Response.Cookies.Delete("refreshToken");
+        Response.Cookies.Delete("refreshToken", new CookieOptions
+        {
+            Path = "/api/auth"
+        });
         return Ok();
     }
 
@@ -86,7 +89,8 @@ public class AuthController : BaseApiController
             HttpOnly = true,
             Secure = true,
             SameSite = SameSiteMode.Strict,
-            Expires = expires
+            Expires = expires,
+            Path = "/api/auth"
         };
         Response.Cookies.Append("refreshToken", refreshToken, cookieOptions);
     }


### PR DESCRIPTION
## Summary
- limit refresh token to auth endpoint path
- ensure cookie deletion uses matching path

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a07ada8fc883278872d39c4f7969ac