### PR TITLE
feat: revoke refresh token on logout

### DIFF
--- a/Frontend.Angular/src/app/services/auth.service.spec.ts
+++ b/Frontend.Angular/src/app/services/auth.service.spec.ts
@@ -1,13 +1,30 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { AuthService } from './auth.service';
+import { NotificationService } from './notification.service';
 
 describe('AuthService', () => {
   let service: AuthService;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: NotificationService, useValue: { stopConnection: () => {} } }
+      ]
+    });
+
+    spyOn(AuthService.prototype as any, 'restoreProfile').and.stub();
+
     service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {
@@ -24,5 +41,19 @@ describe('AuthService', () => {
     });
 
     service.refreshFailed(new Error('fail'));
+  });
+
+  it('should clear session even if revoke fails', () => {
+    (service as any).accessToken = 'token';
+    const clearSpy = spyOn<any>(service, 'clearSession').and.callThrough();
+
+    service.logout();
+
+    const req = httpMock.expectOne(`${(service as any).apiBase}/auth/revoke`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.withCredentials).toBeTrue();
+    req.flush({}, { status: 500, statusText: 'Error' });
+
+    expect(clearSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- revoke refresh token via API before clearing client session
- handle revoke errors gracefully
- cover logout with a unit test

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: module and stylesheet resolution errors)*
- `dotnet test` *(fails: command not found; apt repository 403 during attempted install)*

------
https://chatgpt.com/codex/tasks/task_e_68a07bdb90188327a33430d4d70bb0a9