### PR TITLE
Handle refresh errors in AuthGuard

### DIFF
--- a/Frontend.Angular/src/app/guards/auth.guard.ts
+++ b/Frontend.Angular/src/app/guards/auth.guard.ts
@@ -7,7 +7,7 @@ import {
   UrlTree
 } from '@angular/router';
 import { Observable, of } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, catchError } from 'rxjs/operators';
 
 import { AuthService } from '../services/auth.service';
 
@@ -35,7 +35,16 @@ export class AuthGuard implements CanActivate {
     };
 
     if (this.authService.refreshing) {
-      return this.authService.waitForRefresh().pipe(map(() => evaluate()));
+      return this.authService.waitForRefresh().pipe(
+        map(() => evaluate()),
+        catchError(() =>
+          of(
+            this.router.createUrlTree(['/signin'], {
+              queryParams: { returnUrl: state.url }
+            })
+          )
+        )
+      );
     }
 
     return of(evaluate());


### PR DESCRIPTION
## Summary
- Redirect to sign-in if session refresh fails
- Import `catchError` for refresh error handling

## Testing
- `npm test -- --watch=false` *(fails: Error: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_68a07ee1da588327969046ca27d8f0f2