### PR TITLE
feat: add storage service for safe localStorage access

### DIFF
--- a/Frontend.Angular/src/app/interceptors/auth.interceptor.spec.ts
+++ b/Frontend.Angular/src/app/interceptors/auth.interceptor.spec.ts
@@ -12,6 +12,7 @@ import { Router } from '@angular/router';
 import { SKIP_AUTH, authInterceptor } from './auth.interceptor';
 import { AuthService } from '../services/auth.service';
 import { NotificationService } from '../services/notification.service';
+import { StorageService } from '../services/storage.service';
 import { environment } from '../environments/environment';
 
 class MockRouter {
@@ -40,12 +41,19 @@ describe('authInterceptor', () => {
   let http: HttpClient;
   let httpMock: HttpTestingController;
   let authService: AuthService;
+  let storageSpy: jasmine.SpyObj<StorageService>;
 
   beforeEach(() => {
+    storageSpy = jasmine.createSpyObj('StorageService', ['getItem', 'setItem', 'removeItem']);
+    storageSpy.getItem.and.callFake((key: string) => localStorage.getItem(key));
+    storageSpy.setItem.and.callFake((key: string, value: string) => localStorage.setItem(key, value));
+    storageSpy.removeItem.and.callFake((key: string) => localStorage.removeItem(key));
+
     TestBed.configureTestingModule({
       providers: [
         { provide: Router, useClass: MockRouter },
         { provide: NotificationService, useClass: MockNotificationService },
+        { provide: StorageService, useValue: storageSpy },
         AuthService,
         provideHttpClient(withInterceptors([authInterceptor])),
         provideHttpClientTesting()

--- a/Frontend.Angular/src/app/services/auth.service.spec.ts
+++ b/Frontend.Angular/src/app/services/auth.service.spec.ts
@@ -4,16 +4,24 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { AuthService } from './auth.service';
 import { NotificationService } from './notification.service';
+import { StorageService } from './storage.service';
 
 describe('AuthService', () => {
   let service: AuthService;
   let httpMock: HttpTestingController;
+  let storageSpy: jasmine.SpyObj<StorageService>;
 
   beforeEach(() => {
+    storageSpy = jasmine.createSpyObj('StorageService', ['getItem', 'setItem', 'removeItem']);
+    storageSpy.getItem.and.callFake((key: string) => localStorage.getItem(key));
+    storageSpy.setItem.and.callFake((key: string, value: string) => localStorage.setItem(key, value));
+    storageSpy.removeItem.and.callFake((key: string) => localStorage.removeItem(key));
+
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, RouterTestingModule],
       providers: [
-        { provide: NotificationService, useValue: { stopConnection: () => {} } }
+        { provide: NotificationService, useValue: { stopConnection: () => {} } },
+        { provide: StorageService, useValue: storageSpy }
       ]
     });
 

--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -20,6 +20,7 @@ import {
 import { jwtDecode } from 'jwt-decode';
 
 import { NotificationService } from './notification.service';
+import { StorageService } from './storage.service';
 
 import { environment } from '../environments/environment';
 import { SKIP_AUTH } from '../interceptors/auth.interceptor';
@@ -48,7 +49,8 @@ export class AuthService implements OnDestroy {
   constructor(
     private http: HttpClient,
     private router: Router,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    private storage: StorageService
   ) {
     this.initStorageListener();
     this.restoreProfile();
@@ -202,7 +204,7 @@ export class AuthService implements OnDestroy {
       try {
         this.profileSubject.next(JSON.parse(cached));
       } catch {
-        localStorage.removeItem(this.PROFILE_KEY);
+        this.storage.removeItem(this.PROFILE_KEY);
       }
     }
 
@@ -259,7 +261,7 @@ export class AuthService implements OnDestroy {
     const decoded: any = jwtDecode(token);
     // Persist device id if present in the token
     if (decoded?.device_id) {
-      localStorage.setItem('deviceId', decoded.device_id);
+      this.storage.setItem('deviceId', decoded.device_id);
     }
 
     return {
@@ -304,11 +306,11 @@ export class AuthService implements OnDestroy {
     }
 
   private getStorage(key: string): string | null {
-    return localStorage.getItem(key);
+    return this.storage.getItem(key);
   }
 
   private setStorage(key: string, value: string): void {
-    localStorage.setItem(key, value);
+    this.storage.setItem(key, value);
   }
 
   private clearSession(): void {
@@ -316,7 +318,7 @@ export class AuthService implements OnDestroy {
     this.profileSubject.next(null);
 
     // Remove cached profile only
-    localStorage.removeItem(this.PROFILE_KEY);
+    this.storage.removeItem(this.PROFILE_KEY);
 
     this.cancelRefresh();
     this.notificationService.stopConnection();

--- a/Frontend.Angular/src/app/services/storage.service.ts
+++ b/Frontend.Angular/src/app/services/storage.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class StorageService {
+  private isBrowser(): boolean {
+    return typeof window !== 'undefined' && !!window.localStorage;
+  }
+
+  getItem(key: string): string | null {
+    return this.isBrowser() ? window.localStorage.getItem(key) : null;
+  }
+
+  setItem(key: string, value: string): void {
+    if (this.isBrowser()) {
+      window.localStorage.setItem(key, value);
+    }
+  }
+
+  removeItem(key: string): void {
+    if (this.isBrowser()) {
+      window.localStorage.removeItem(key);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- wrap browser storage access in new StorageService
- refactor AuthService to depend on StorageService
- mock StorageService in unit tests

## Testing
- `npm test -- --watch=false` *(fails: Module not found and missing stylesheet errors)*


------
https://chatgpt.com/codex/tasks/task_e_68a0803f94848327afa17dd39f54e612