### PR TITLE
Clean up session on auth guard token refresh failures

### DIFF
--- a/Frontend.Angular/src/app/guards/auth.guard.ts
+++ b/Frontend.Angular/src/app/guards/auth.guard.ts
@@ -1,7 +1,7 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 import { of } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { catchError, map, take } from 'rxjs/operators';
 
 import { AuthService } from '../services/auth.service';
 
@@ -12,7 +12,11 @@ export const authGuard: CanActivateFn = (_route, state) => {
   if (auth.isAuthenticated()) return true;
 
   return auth.ensureAccessToken().pipe(
+    take(1),
     map(ok => ok ? true : router.createUrlTree(['/signin'], { queryParams: { returnUrl: state.url } })),
-    catchError(() => of(router.createUrlTree(['/signin'], { queryParams: { returnUrl: state.url } })))
+    catchError(() => {
+      auth.logout(false);
+      return of(router.createUrlTree(['/signin'], { queryParams: { returnUrl: state.url } }));
+    })
   );
 };


### PR DESCRIPTION
## Summary
- Log out on auth guard errors before redirecting to sign-in
- Finish auth guard after a single access token emission

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: Error: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_68a09bb8f5a083278841ba44daf4abaf