### PR TITLE
fix: export AuthGuard from guard

### DIFF
--- a/Frontend.Angular/src/app/guards/auth.guard.ts
+++ b/Frontend.Angular/src/app/guards/auth.guard.ts
@@ -5,7 +5,7 @@ import { catchError, map, take } from 'rxjs/operators';
 
 import { AuthService } from '../services/auth.service';
 
-export const authGuard: CanActivateFn = (_route, state) => {
+export const AuthGuard: CanActivateFn = (_route, state) => {
   const auth = inject(AuthService);
   const router = inject(Router);
 


### PR DESCRIPTION
## Summary
- rename `authGuard` export to `AuthGuard`
- adjust imports to align with new `AuthGuard` symbol

## Testing
- `npm test -- --watch=false` *(fails: many TypeScript and stylesheet resolution errors)*
- `npm run build` *(fails: external font stylesheets blocked with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a2d758bc8327be653a5b59ecae9a