### PR TITLE
feat(auth): centralize sign-in redirect

### DIFF
--- a/Frontend.Angular/src/app/guards/auth.guard.ts
+++ b/Frontend.Angular/src/app/guards/auth.guard.ts
@@ -1,5 +1,5 @@
 import { inject } from '@angular/core';
-import { CanActivateFn, Router } from '@angular/router';
+import { CanActivateFn } from '@angular/router';
 import { of } from 'rxjs';
 import { catchError, map, take } from 'rxjs/operators';
 
@@ -7,16 +7,15 @@ import { AuthService } from '../services/auth.service';
 
 export const AuthGuard: CanActivateFn = (_route, state) => {
   const auth = inject(AuthService);
-  const router = inject(Router);
 
   if (auth.isAuthenticated()) return true;
 
   return auth.ensureAccessToken().pipe(
     take(1),
-    map(ok => ok ? true : router.createUrlTree(['/signin'], { queryParams: { returnUrl: state.url } })),
+    map(ok => ok ? true : auth.redirectToSignIn(state.url)),
     catchError(() => {
       auth.logout(false);
-      return of(router.createUrlTree(['/signin'], { queryParams: { returnUrl: state.url } }));
+      return of(auth.redirectToSignIn(state.url));
     })
   );
 };

--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpContext, HttpErrorResponse } from '@angular/common/http';
 import { Injectable, OnDestroy } from '@angular/core';
-import { Router } from '@angular/router';
+import { Router, UrlTree } from '@angular/router';
 import { BehaviorSubject, Observable, of, Subscription, throwError, timer } from 'rxjs';
 import { catchError, finalize, map, retry, shareReplay, switchMap, take, tap } from 'rxjs/operators';
 import { jwtDecode } from 'jwt-decode';
@@ -93,9 +93,13 @@ export class AuthService implements OnDestroy {
     .subscribe(() => {
       this.clearSession();
       if (navigate) {
-        this.router.navigate(['/signin'], { queryParams: { returnUrl: this.router.url } });
+        this.router.navigateByUrl(this.redirectToSignIn());
       }
     });
+  }
+
+  redirectToSignIn(returnUrl: string = this.router.url): UrlTree {
+    return this.router.createUrlTree(['/signin'], { queryParams: { returnUrl } });
   }
 
   /** Ensure a valid access token; otherwise refresh via cookie. */
@@ -241,7 +245,7 @@ export class AuthService implements OnDestroy {
 
     this.refreshTimer?.unsubscribe(); this.refreshTimer = undefined;
     this.notifications.stopConnection();
-    if (navigate) this.router.navigate(['/signin']);
+    if (navigate) this.router.navigateByUrl(this.redirectToSignIn());
   }
 
   private appError(err: HttpErrorResponse | any) {


### PR DESCRIPTION
## Summary
- centralize sign-in redirect in AuthService
- use redirect helper from auth guard

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Error: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a4b02f148327a94bb767981f4dde