### PR TITLE
fix: attach token during logout

### DIFF
--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -87,7 +87,7 @@ export class AuthService implements OnDestroy {
     this.http.post(
       `${this.api}/auth/revoke`,
       {},
-      { withCredentials: true, context: new HttpContext().set(SKIP_AUTH, true) }
+      { withCredentials: true }
     )
     .pipe(catchError(() => of(null)))
     .subscribe(() => {


### PR DESCRIPTION
## Summary
- ensure logout request includes auth token by removing SKIP_AUTH context

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e0098050832794017393303ffb66