### PR TITLE
Ensure auth token before app initialization

### DIFF
--- a/Frontend.Angular/src/app/app.component.ts
+++ b/Frontend.Angular/src/app/app.component.ts
@@ -25,8 +25,9 @@ export class AppComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
-    // Check if the user is logged in
-    if (this.authService.isAuthenticated()) {
+    this.authService.ensureAccessToken().subscribe(isAuth => {
+      if (!isAuth) return;  // user not signed in
+
       // Payment
       this.configService.loadConfig().subscribe({
         next: () => console.log('Config loaded:', this.configService.get('apiUrl')),
@@ -56,6 +57,6 @@ export class AppComponent implements OnInit {
           this.toastr.info(notification.data.content, notification.message);
         }
       });
-    }
+    });
   }
 }


### PR DESCRIPTION
## Summary
- trigger app initialization after ensuring auth token via `ensureAccessToken`

## Testing
- `CI=true npm test -- --watch=false` *(fails: Generating browser application bundles... then aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f0c86fb88327b2425305bf6ccd75