### PR TITLE
Refactor token refresh to central AuthService

### DIFF
--- a/Frontend.Angular/src/app/app.component.ts
+++ b/Frontend.Angular/src/app/app.component.ts
@@ -26,13 +26,8 @@ export class AppComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
-      this.authService.ensureAccessToken().subscribe(isAuth => {
-        if (!isAuth) {
-          this.toastr.info('Your session expired. Please sign in again.');
-          this.authService.logout(false);
-          return;
-        }
-
+    this.authService.getValidAccessToken().subscribe({
+      next: () => {
         // Payment
         this.configService.loadConfig().subscribe({
           next: () => console.log('Config loaded:', this.configService.get('apiUrl')),
@@ -62,6 +57,11 @@ export class AppComponent implements OnInit {
             this.toastr.info(notification.data.content, notification.message);
           }
         });
-      });
-    }
+      },
+      error: () => {
+        this.toastr.info('Your session expired. Please sign in again.');
+        this.authService.logout(false);
+      }
+    });
+  }
 }

--- a/Frontend.Angular/src/app/guards/auth.guard.ts
+++ b/Frontend.Angular/src/app/guards/auth.guard.ts
@@ -8,9 +8,9 @@ import { AuthService } from '../services/auth.service';
 export const AuthGuard: CanActivateFn = (_route, state) => {
   const auth = inject(AuthService);
 
-  return auth.ensureAccessToken().pipe(
+  return auth.getValidAccessToken().pipe(
     take(1),
-    map(ok => ok ? true : auth.redirectToSignIn(state.url)),
+    map(() => true),
     catchError(() => {
       auth.logout(false);
       return of(auth.redirectToSignIn(state.url));

--- a/Frontend.Angular/src/app/interceptors/auth.interceptor.ts
+++ b/Frontend.Angular/src/app/interceptors/auth.interceptor.ts
@@ -6,7 +6,7 @@ import {
   HttpRequest
 } from '@angular/common/http';
 import { inject } from '@angular/core';
-import { from,Observable, throwError } from 'rxjs';
+import { from, Observable, throwError } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 
 import { AuthService } from '../services/auth.service';
@@ -24,9 +24,8 @@ export function authInterceptor(req: HttpRequest<any>, next: HttpHandlerFn): Obs
   if (skip || !toApi) return next(req.clone({ withCredentials: true }));
 
   // PRE-WAIT: avoid sending requests without a token on reload
-  return from(auth.ensureAccessToken()).pipe(
-    switchMap(() => {
-      const token = auth.getAccessToken();
+  return from(auth.getValidAccessToken()).pipe(
+    switchMap(token => {
       const deviceId = auth.getDeviceIdForHeader();
       return next(withAuth(req, token, deviceId));
     }),

--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -102,13 +102,11 @@ export class AuthService implements OnDestroy {
     return this.router.createUrlTree(['/signin'], { queryParams: { returnUrl } });
   }
 
-  /** Ensure a valid access token; otherwise refresh via cookie. */
-  ensureAccessToken(): Observable<boolean> {
-    if (this.isAuthenticated()) return of(true);
-    return this.refreshAccessToken().pipe(
-      map(() => true),
-      catchError(() => of(false))
-    );
+  /** Obtain a valid access token, refreshing silently if needed. */
+  getValidAccessToken(): Observable<string> {
+    return this.isAuthenticated()
+      ? of(this.accessToken as string)
+      : this.refreshAccessToken();
   }
 
   getProfile(): UserProfile | null { return this.profileSubject.value; }


### PR DESCRIPTION
## Summary
- centralize access token handling via new `getValidAccessToken` helper
- update guard, interceptor, and app bootstrap to use shared refresh logic

## Testing
- `npm test -- --watch=false --progress=false` *(fails: process terminated)*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68a1d36dd904832796691c16a299a4ee