### PR TITLE
feat: use backend cookie for device id

### DIFF
--- a/Frontend.Angular/src/app/models/UserProfile.ts
+++ b/Frontend.Angular/src/app/models/UserProfile.ts
@@ -7,7 +7,6 @@ export interface UserProfile {
   timeZoneId?: string;
   ipAddress?: string;
   imageUrl?: string;
-  deviceId?: string;
   roles: string[];        // multiple roles
   permissions: string[];  // permissions as strings
   exp?: number;           // token expiration (epoch seconds)

--- a/admin/Infrastructure/Auth/Jwt/JwtAuthenticationHeaderHandler.cs
+++ b/admin/Infrastructure/Auth/Jwt/JwtAuthenticationHeaderHandler.cs
@@ -1,7 +1,3 @@
-using System.Text.Json;
-using Avancira.Admin.Infrastructure.Storage;
-using Avancira.Shared.Authorization;
-using Blazored.LocalStorage;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication.Internal;
 using System.Net.Http.Headers;
@@ -12,68 +8,29 @@ public class JwtAuthenticationHeaderHandler : DelegatingHandler
 {
     private readonly IAccessTokenProviderAccessor _tokenProviderAccessor;
     private readonly NavigationManager _navigation;
-    private readonly ILocalStorageService _localStorage;
 
     public JwtAuthenticationHeaderHandler(
         IAccessTokenProviderAccessor tokenProviderAccessor,
-        NavigationManager navigation,
-        ILocalStorageService localStorage)
+        NavigationManager navigation)
     {
         _tokenProviderAccessor = tokenProviderAccessor;
         _navigation = navigation;
-        _localStorage = localStorage;
     }
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        string? deviceId = await _localStorage.GetItemAsync<string>(StorageConstants.Local.DeviceId);
-
         if (request.RequestUri?.AbsolutePath.Contains("/auth") != true)
         {
             if (await _tokenProviderAccessor.TokenProvider.GetAccessTokenAsync() is string token)
             {
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-                try
-                {
-                    string payload = token.Split('.')[1];
-                    byte[] jsonBytes = ParseBase64WithoutPadding(payload);
-                    var keyValuePairs = JsonSerializer.Deserialize<Dictionary<string, object>>(jsonBytes);
-                    if (keyValuePairs != null &&
-                        keyValuePairs.TryGetValue(AvanciraClaims.DeviceId, out var claim) &&
-                        claim is not null)
-                    {
-                        deviceId = claim.ToString();
-                        await _localStorage.SetItemAsync(StorageConstants.Local.DeviceId, deviceId);
-                    }
-                }
-                catch
-                {
-                    // ignore decoding errors
-                }
             }
             else
             {
                 _navigation.NavigateTo("/login");
             }
         }
-
-        if (string.IsNullOrEmpty(deviceId))
-        {
-            deviceId = Guid.NewGuid().ToString();
-            await _localStorage.SetItemAsync(StorageConstants.Local.DeviceId, deviceId);
-        }
-
-        request.Headers.TryAddWithoutValidation("Device-Id", deviceId);
-
         return await base.SendAsync(request, cancellationToken);
-    }
-
-    private static byte[] ParseBase64WithoutPadding(string payload)
-    {
-        payload = payload.Trim().Replace('-', '+').Replace('_', '/');
-        string base64 = payload.PadRight(payload.Length + (4 - payload.Length % 4) % 4, '=');
-        return Convert.FromBase64String(base64);
     }
 }
 

--- a/admin/Infrastructure/Storage/StorageConstants.cs
+++ b/admin/Infrastructure/Storage/StorageConstants.cs
@@ -9,6 +9,5 @@ public static class StorageConstants
         public static string RefreshToken = "refreshToken";
         public static string ImageUri = "userImageURL";
         public static string Permissions = "permissions";
-        public static string DeviceId = "deviceId";
     }
 }

--- a/api/Avancira.Infrastructure/Common/Extensions/HttpContextExtensions.cs
+++ b/api/Avancira.Infrastructure/Common/Extensions/HttpContextExtensions.cs
@@ -20,11 +20,18 @@ public static class HttpContextExtensions
 
     public static string GetDeviceIdentifier(this HttpContext context)
     {
-        var deviceId = context.Request.Headers["Device-Id"].FirstOrDefault();
-
+        var deviceId = context.Request.Cookies["device_id"];
         if (string.IsNullOrEmpty(deviceId))
         {
             deviceId = Guid.NewGuid().ToString();
+            context.Response.Cookies.Append("device_id", deviceId, new CookieOptions
+            {
+                HttpOnly = true,
+                Secure = true,
+                SameSite = SameSiteMode.None,
+                Expires = DateTime.UtcNow.AddYears(1),
+                Path = "/api/auth"
+            });
         }
 
         return deviceId;

--- a/api/Avancira.Infrastructure/Identity/Tokens/TokenService.cs
+++ b/api/Avancira.Infrastructure/Identity/Tokens/TokenService.cs
@@ -205,7 +205,6 @@ public sealed class TokenService : ITokenService
             new(ClaimTypes.MobilePhone, user.PhoneNumber ?? string.Empty),
             new(AvanciraClaims.TimeZoneId, user.TimeZoneId ?? string.Empty),
             new(AvanciraClaims.IpAddress, ipAddress),
-            new(AvanciraClaims.DeviceId, deviceId),
             new(AvanciraClaims.ImageUrl, user.ImageUrl == null ? string.Empty : user.ImageUrl.ToString())
         };
 

--- a/api/Avancira.Shared/Authorization/AvanciraClaims.cs
+++ b/api/Avancira.Shared/Authorization/AvanciraClaims.cs
@@ -5,7 +5,6 @@ public static class AvanciraClaims
     public const string Permission = "permission";
     public const string ImageUrl = "image_url";
     public const string IpAddress = "ipAddress";
-    public const string DeviceId = "device_id";
     public const string TimeZoneId = "timeZoneId";
     public const string Expiration = "exp";
 }


### PR DESCRIPTION
## Summary
- drop Device-Id claim and constant, relying on server-issued cookie for device tracking
- generate device_id cookie server-side and remove device header usage
- remove deviceId from front-end user profile and token decoding

## Testing
- `npm test -- --watch=false` *(hangs while generating browser bundles)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2242670f88327a08581f57b39234d