### PR TITLE
Set device_id cookie for global path

### DIFF
--- a/api/Avancira.Infrastructure/Common/ClientInfoService.cs
+++ b/api/Avancira.Infrastructure/Common/ClientInfoService.cs
@@ -34,7 +34,7 @@ public class ClientInfoService : IClientInfoService
                 Secure = true,
                 SameSite = SameSiteMode.None,
                 Expires = DateTime.UtcNow.AddYears(1),
-                Path = "/api/auth"
+                Path = "/"
             });
         }
 


### PR DESCRIPTION
## Summary
- allow `device_id` cookie to be sent on non-auth endpoints by setting cookie path to `/`

## Testing
- `dotnet test` *(fails: command not found)*
- `curl -I http://localhost:5000/` *(fails: couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68a488ca71e4832780334004e1eaca16