### PR TITLE
Allow refresh without access token

### DIFF
--- a/api/Avancira.API.Tests/Avancira.API.Tests.csproj
+++ b/api/Avancira.API.Tests/Avancira.API.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Avancira.API\Avancira.API.csproj" />
+    <ProjectReference Include="..\Avancira.Application\Avancira.Application.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Moq" Version="4.20.2" />
+    <PackageReference Include="FluentValidation.TestHelper" Version="11.11.0" />
+  </ItemGroup>
+</Project>

--- a/api/Avancira.API.Tests/RefreshTokenTests.cs
+++ b/api/Avancira.API.Tests/RefreshTokenTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avancira.API.Controllers;
+using Avancira.Application.Common;
+using Avancira.Application.Identity.Tokens;
+using Avancira.Application.Identity.Tokens.Dtos;
+using Avancira.Application.Identity.Tokens.Validators;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+public class RefreshTokenTests
+{
+    [Fact]
+    public async Task RefreshToken_WithAccessToken_ReturnsTokenResponse()
+    {
+        var tokenService = new Mock<ITokenService>();
+        var clientInfoService = new Mock<IClientInfoService>();
+        var clientInfo = new ClientInfo
+        {
+            DeviceId = "device",
+            IpAddress = "1.1.1.1",
+            UserAgent = "agent",
+            OperatingSystem = "os"
+        };
+        clientInfoService.Setup(s => s.GetClientInfoAsync()).ReturnsAsync(clientInfo);
+
+        var tokenPair = new TokenPair("newAccess", "newRefresh", DateTime.UtcNow.AddMinutes(5));
+        tokenService.Setup(s => s.RefreshTokenAsync("expired", "refreshCookie", clientInfo, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(tokenPair);
+
+        var controller = new AuthController(tokenService.Object, clientInfoService.Object);
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Cookie"] = "refreshToken=refreshCookie";
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        var request = new RefreshTokenDto("expired");
+        var result = await controller.RefreshToken(request, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<TokenResponse>(ok.Value);
+        response.Token.Should().Be("newAccess");
+        tokenService.Verify(s => s.RefreshTokenAsync("expired", "refreshCookie", clientInfo, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RefreshToken_WithoutAccessToken_ReturnsTokenResponse()
+    {
+        var tokenService = new Mock<ITokenService>();
+        var clientInfoService = new Mock<IClientInfoService>();
+        var clientInfo = new ClientInfo
+        {
+            DeviceId = "device",
+            IpAddress = "1.1.1.1",
+            UserAgent = "agent",
+            OperatingSystem = "os"
+        };
+        clientInfoService.Setup(s => s.GetClientInfoAsync()).ReturnsAsync(clientInfo);
+
+        var tokenPair = new TokenPair("newAccess", "newRefresh", DateTime.UtcNow.AddMinutes(5));
+        tokenService.Setup(s => s.RefreshTokenAsync(null, "refreshCookie", clientInfo, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(tokenPair);
+
+        var controller = new AuthController(tokenService.Object, clientInfoService.Object);
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Cookie"] = "refreshToken=refreshCookie";
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        var result = await controller.RefreshToken(null, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<TokenResponse>(ok.Value);
+        response.Token.Should().Be("newAccess");
+        tokenService.Verify(s => s.RefreshTokenAsync(null, "refreshCookie", clientInfo, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public void Validator_AllowsMissingToken()
+    {
+        var validator = new RefreshTokenValidator();
+        var result = validator.TestValidate(new RefreshTokenDto(null));
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validator_AllowsProvidedToken()
+    {
+        var validator = new RefreshTokenValidator();
+        var result = validator.TestValidate(new RefreshTokenDto("token"));
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/api/Avancira.Application/Identity/Tokens/Dtos/RefreshTokenDto.cs
+++ b/api/Avancira.Application/Identity/Tokens/Dtos/RefreshTokenDto.cs
@@ -1,8 +1,8 @@
 namespace Avancira.Application.Identity.Tokens.Dtos;
 
 /// <summary>
-/// Request payload for refreshing an access token. Only the (potentially expired)
-/// access token is sent by the client. The refresh token is supplied via a
-/// secure HttpOnly cookie.
+/// Request payload for refreshing an access token. The (potentially expired)
+/// access token may be provided by the client, but it can be omitted if not
+/// available. The refresh token is supplied via a secure HttpOnly cookie.
 /// </summary>
 public record RefreshTokenDto(string? Token);

--- a/api/Avancira.Application/Identity/Tokens/Validators/RefreshTokenValidator.cs
+++ b/api/Avancira.Application/Identity/Tokens/Validators/RefreshTokenValidator.cs
@@ -7,6 +7,6 @@ public class RefreshTokenValidator : AbstractValidator<RefreshTokenDto>
 {
     public RefreshTokenValidator()
     {
-        RuleFor(p => p.Token).Cascade(CascadeMode.Stop).NotEmpty();
+        // Access token is optional when refreshing, so no validation rules are required.
     }
 }


### PR DESCRIPTION
## Summary
- document optional access token in refresh endpoint
- remove token NotEmpty rule and add tests for missing token

## Testing
- `dotnet test api/Avancira.API.Tests/Avancira.API.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a48a0bcb208327b6b6285317ed5aa1