### PR TITLE
Add issuer and audience to JWT configuration

### DIFF
--- a/api/Avancira.API/appsettings.json
+++ b/api/Avancira.API/appsettings.json
@@ -16,6 +16,8 @@
   },
   "JwtOptions": {
     "Key": "QsJbczCNysv/5SGh+U7sxedX8C07TPQPBdsnSDKZ/aE=",
+    "Issuer": "https://fullstackhero.net",
+    "Audience": "avancira",
     "TokenExpirationInMinutes": 10,
     "RefreshTokenExpirationInDays": 7
   },

--- a/api/Avancira.Application/Auth/Jwt/JwtOptions.cs
+++ b/api/Avancira.Application/Auth/Jwt/JwtOptions.cs
@@ -5,6 +5,10 @@ public class JwtOptions : IValidatableObject
 {
     public string Key { get; set; } = string.Empty;
 
+    public string Issuer { get; set; } = string.Empty;
+
+    public string Audience { get; set; } = string.Empty;
+
     public int TokenExpirationInMinutes { get; set; } = 60;
 
     public int RefreshTokenExpirationInDays { get; set; } = 7;
@@ -13,7 +17,17 @@ public class JwtOptions : IValidatableObject
     {
         if (string.IsNullOrEmpty(Key))
         {
-            yield return new ValidationResult("No Key defined in JwtSettings config", [nameof(Key)]);
+            yield return new ValidationResult("No Key defined in JwtOptions config", [nameof(Key)]);
+        }
+
+        if (string.IsNullOrEmpty(Issuer))
+        {
+            yield return new ValidationResult("No Issuer defined in JwtOptions config", [nameof(Issuer)]);
+        }
+
+        if (string.IsNullOrEmpty(Audience))
+        {
+            yield return new ValidationResult("No Audience defined in JwtOptions config", [nameof(Audience)]);
         }
     }
 }

--- a/api/Avancira.Infrastructure/Auth/Jwt/ConfigureJwtBearerOptions.cs
+++ b/api/Avancira.Infrastructure/Auth/Jwt/ConfigureJwtBearerOptions.cs
@@ -37,10 +37,10 @@ public class ConfigureJwtBearerOptions : IConfigureNamedOptions<JwtBearerOptions
         {
             ValidateIssuerSigningKey = true,
             IssuerSigningKey = new SymmetricSecurityKey(key),
-            ValidIssuer = JwtAuthConstants.Issuer,
+            ValidIssuer = _options.Issuer,
             ValidateIssuer = true,
             ValidateLifetime = true,
-            ValidAudience = JwtAuthConstants.Audience,
+            ValidAudience = _options.Audience,
             ValidateAudience = true,
             RoleClaimType = ClaimTypes.Role,
             ClockSkew = TimeSpan.Zero

--- a/api/Avancira.Infrastructure/Auth/Jwt/JwtAuthConstants.cs
+++ b/api/Avancira.Infrastructure/Auth/Jwt/JwtAuthConstants.cs
@@ -1,6 +1,0 @@
-﻿namespace Avancira.Infrastructure.Auth.Jwt;
-internal static class JwtAuthConstants
-{
-    public const string Issuer = "https://fullstackhero.net";
-    public const string Audience = "avancira";
-}

--- a/api/Avancira.Infrastructure/Identity/Tokens/TokenService.cs
+++ b/api/Avancira.Infrastructure/Identity/Tokens/TokenService.cs
@@ -3,7 +3,6 @@ using Avancira.Application.Common;
 using Avancira.Application.Identity.Tokens;
 using Avancira.Application.Identity.Tokens.Dtos;
 using Avancira.Domain.Common.Exceptions;
-using Avancira.Infrastructure.Auth.Jwt;
 using Avancira.Infrastructure.Identity.Audit;
 using Avancira.Infrastructure.Identity.Users;
 using Avancira.Infrastructure.Persistence;
@@ -339,8 +338,8 @@ public sealed class TokenService : ITokenService
             claims: claims,
             expires: DateTime.UtcNow.AddMinutes(_jwtOptions.TokenExpirationInMinutes),
             signingCredentials: signingCredentials,
-            issuer: JwtAuthConstants.Issuer,
-            audience: JwtAuthConstants.Audience
+            issuer: _jwtOptions.Issuer,
+            audience: _jwtOptions.Audience
         );
         var tokenHandler = new JwtSecurityTokenHandler();
         return tokenHandler.WriteToken(token);
@@ -392,8 +391,8 @@ public sealed class TokenService : ITokenService
             IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtOptions.Key)),
             ValidateIssuer = true,
             ValidateAudience = true,
-            ValidAudience = JwtAuthConstants.Audience,
-            ValidIssuer = JwtAuthConstants.Issuer,
+            ValidAudience = _jwtOptions.Audience,
+            ValidIssuer = _jwtOptions.Issuer,
             RoleClaimType = ClaimTypes.Role,
             ClockSkew = TimeSpan.Zero,
             ValidateLifetime = false

--- a/aspire/Avancira.Host/appsettings.json
+++ b/aspire/Avancira.Host/appsettings.json
@@ -5,5 +5,11 @@
       "Microsoft.AspNetCore": "Warning",
       "Aspire.Hosting.Dcp": "Warning"
     }
+  },
+  "Avancira": {
+    "Jwt": {
+      "Issuer": "https://fullstackhero.net",
+      "Audience": "avancira"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- load JWT issuer and audience from configuration
- remove `JwtAuthConstants` and use `JwtOptions`
- document issuer and audience settings

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a48cd5dbe88327b99fd8ea17fa551a