### PR TITLE
Add session management support

### DIFF
--- a/Frontend.Angular/src/app/app.routes.ts
+++ b/Frontend.Angular/src/app/app.routes.ts
@@ -18,6 +18,7 @@ import { MessagesComponent } from './pages/messages/messages.component';
 import { PaymentsComponent } from './pages/payments/payments.component';
 import { PrivacyComponent } from './pages/privacy/privacy.component';
 import { ProfileComponent } from './pages/profile/profile.component';
+import { SessionsComponent } from './pages/sessions/sessions.component';
 import { ResetPasswordComponent } from './pages/reset-password/reset-password.component';
 import { SigninComponent } from './pages/signin/signin.component';
 import { SignupComponent } from './pages/signup/signup.component';
@@ -82,6 +83,7 @@ export const routes: Routes = [
               { path: 'payments', component: PaymentsComponent, data: { title: 'Payments' } },
               { path: 'invoices', component: InvoicesComponent, data: { title: 'Invoices' } },
               { path: 'profile', component: ProfileComponent, data: { title: 'Profile' } },
+              { path: 'sessions', component: SessionsComponent, data: { title: 'Sessions' } },
             ]
           }
         ]

--- a/Frontend.Angular/src/app/models/session.ts
+++ b/Frontend.Angular/src/app/models/session.ts
@@ -1,0 +1,13 @@
+export interface Session {
+  id: string;
+  device: string;
+  userAgent?: string;
+  operatingSystem?: string;
+  ipAddress: string;
+  country?: string;
+  city?: string;
+  createdUtc: string;
+  lastActivityUtc: string;
+  absoluteExpiryUtc: string;
+  revokedUtc?: string;
+}

--- a/Frontend.Angular/src/app/pages/sessions/sessions.component.html
+++ b/Frontend.Angular/src/app/pages/sessions/sessions.component.html
@@ -1,0 +1,11 @@
+<div class="sessions">
+  <h2>Active Sessions</h2>
+  <div *ngIf="loading">Loading...</div>
+  <ul *ngIf="!loading && sessions.length">
+    <li *ngFor="let session of sessions">
+      <span>{{ session.device }} ({{ session.ipAddress }}) - Last active: {{ session.lastActivityUtc | date:'short' }}</span>
+      <button type="button" (click)="revoke(session)">Revoke</button>
+    </li>
+  </ul>
+  <p *ngIf="!loading && sessions.length === 0">No active sessions.</p>
+</div>

--- a/Frontend.Angular/src/app/pages/sessions/sessions.component.scss
+++ b/Frontend.Angular/src/app/pages/sessions/sessions.component.scss
@@ -1,0 +1,12 @@
+.sessions {
+  ul {
+    list-style: none;
+    padding: 0;
+  }
+  li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+  }
+}

--- a/Frontend.Angular/src/app/pages/sessions/sessions.component.ts
+++ b/Frontend.Angular/src/app/pages/sessions/sessions.component.ts
@@ -1,0 +1,43 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+
+import { Session } from '../../models/session';
+import { SessionService } from '../../services/session.service';
+
+@Component({
+  selector: 'app-sessions',
+  imports: [CommonModule],
+  templateUrl: './sessions.component.html',
+  styleUrl: './sessions.component.scss'
+})
+export class SessionsComponent implements OnInit {
+  sessions: Session[] = [];
+  loading = false;
+
+  constructor(private sessionService: SessionService) {}
+
+  ngOnInit(): void {
+    this.loadSessions();
+  }
+
+  loadSessions(): void {
+    this.loading = true;
+    this.sessionService.getSessions().subscribe({
+      next: s => {
+        this.sessions = s;
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+      }
+    });
+  }
+
+  revoke(session: Session): void {
+    this.sessionService.revokeSession(session.id).subscribe({
+      next: () => {
+        this.sessions = this.sessions.filter(x => x.id !== session.id);
+      }
+    });
+  }
+}

--- a/Frontend.Angular/src/app/services/session.service.spec.ts
+++ b/Frontend.Angular/src/app/services/session.service.spec.ts
@@ -1,0 +1,19 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+import { SessionService } from './session.service';
+
+describe('SessionService', () => {
+  let service: SessionService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(SessionService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/Frontend.Angular/src/app/services/session.service.ts
+++ b/Frontend.Angular/src/app/services/session.service.ts
@@ -1,0 +1,26 @@
+import { HttpClient, HttpContext } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { environment } from '../environments/environment';
+import { INCLUDE_CREDENTIALS, REQUIRES_AUTH } from '../interceptors/auth.interceptor';
+import { Session } from '../models/session';
+
+@Injectable({ providedIn: 'root' })
+export class SessionService {
+  private readonly api = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getSessions(): Observable<Session[]> {
+    return this.http.get<Session[]>(`${this.api}/auth/sessions`, {
+      context: new HttpContext().set(REQUIRES_AUTH, true).set(INCLUDE_CREDENTIALS, true)
+    });
+  }
+
+  revokeSession(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.api}/auth/sessions/${id}`, {
+      context: new HttpContext().set(REQUIRES_AUTH, true).set(INCLUDE_CREDENTIALS, true)
+    });
+  }
+}

--- a/api/Avancira.Application/Identity/Tokens/Dtos/SessionDto.cs
+++ b/api/Avancira.Application/Identity/Tokens/Dtos/SessionDto.cs
@@ -9,5 +9,6 @@ public record SessionDto(
     string? Country,
     string? City,
     DateTime CreatedUtc,
+    DateTime LastActivityUtc,
     DateTime AbsoluteExpiryUtc,
     DateTime? RevokedUtc);

--- a/api/Avancira.Infrastructure/Identity/Tokens/TokenService.cs
+++ b/api/Avancira.Infrastructure/Identity/Tokens/TokenService.cs
@@ -167,7 +167,8 @@ public sealed class TokenService : ITokenService
     {
         return await _dbContext.Sessions
             .AsNoTracking()
-            .Where(s => s.UserId == userId)
+            .Where(s => s.UserId == userId && s.RevokedUtc == null && s.AbsoluteExpiryUtc > DateTime.UtcNow)
+            .OrderByDescending(s => s.LastActivityUtc)
             .Select(s => new SessionDto(
                 s.Id,
                 s.Device,
@@ -177,6 +178,7 @@ public sealed class TokenService : ITokenService
                 s.Country,
                 s.City,
                 s.CreatedUtc,
+                s.LastActivityUtc,
                 s.AbsoluteExpiryUtc,
                 s.RevokedUtc))
             .ToListAsync(ct);


### PR DESCRIPTION
## Summary
- expose session last activity in backend session DTO and filter to active sessions
- add Angular service and page to view and revoke sessions
- wire session management route into dashboard

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test --prefix Frontend.Angular` *(fails: Missing exports and stylesheet errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a490c776948327aa751d542820297f