### PR TITLE
feat(frontend): enhance sessions table

### DIFF
--- a/Frontend.Angular/src/app/pages/sessions/sessions.component.html
+++ b/Frontend.Angular/src/app/pages/sessions/sessions.component.html
@@ -1,11 +1,28 @@
-<div class="sessions">
-  <h2>Active Sessions</h2>
-  <div *ngIf="loading">Loading...</div>
-  <ul *ngIf="!loading && sessions.length">
-    <li *ngFor="let session of sessions">
-      <span>{{ session.device }} ({{ session.ipAddress }}) - Last active: {{ session.lastActivityUtc | date:'short' }}</span>
-      <button type="button" (click)="revoke(session)">Revoke</button>
-    </li>
-  </ul>
-  <p *ngIf="!loading && sessions.length === 0">No active sessions.</p>
+<div class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card border-0">
+          <div class="card-header text-white">
+            <h5 class="mb-0">Active Sessions</h5>
+          </div>
+          <div class="card-body">
+            <p *ngIf="loading">Loading...</p>
+            <app-table *ngIf="!loading"
+              [data]="pagedSessions"
+              [columns]="sessionColumns"
+              [actions]="sessionActions"
+              [page]="page"
+              [pageSize]="pageSize"
+              [totalResults]="totalResults"
+              [pageSizeOptions]="pageSizeOptions"
+              (pageChange)="onPageChange($event)"
+              (pageSizeChange)="onPageSizeChange($event)">
+            </app-table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
+

--- a/Frontend.Angular/src/app/pages/sessions/sessions.component.scss
+++ b/Frontend.Angular/src/app/pages/sessions/sessions.component.scss
@@ -1,12 +1,2 @@
-.sessions {
-  ul {
-    list-style: none;
-    padding: 0;
-  }
-  li {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 0.5rem;
-  }
-}
+/* Styles for the sessions page */
+

--- a/Frontend.Angular/src/app/pages/sessions/sessions.component.ts
+++ b/Frontend.Angular/src/app/pages/sessions/sessions.component.ts
@@ -1,18 +1,48 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 
+import { TableComponent } from '../../layout/shared/table/table.component';
 import { Session } from '../../models/session';
 import { SessionService } from '../../services/session.service';
 
 @Component({
   selector: 'app-sessions',
-  imports: [CommonModule],
+  imports: [CommonModule, TableComponent],
   templateUrl: './sessions.component.html',
   styleUrl: './sessions.component.scss'
 })
 export class SessionsComponent implements OnInit {
   sessions: Session[] = [];
+  pagedSessions: Session[] = [];
   loading = false;
+
+  page = 1;
+  pageSize = 10;
+  pageSizeOptions = [5, 10, 50, 100];
+  totalResults = 0;
+
+  sessionColumns = [
+    { key: 'device', label: 'Device' },
+    { key: 'operatingSystem', label: 'OS' },
+    { key: 'userAgent', label: 'Agent' },
+    { key: 'ipAddress', label: 'IP Address' },
+    { key: 'country', label: 'Country' },
+    { key: 'city', label: 'City' },
+    {
+      key: 'lastActivityUtc',
+      label: 'Last Active',
+      formatter: (value: any) => value ? new Date(value).toLocaleString() : ''
+    }
+  ];
+
+  sessionActions = [
+    {
+      label: 'Revoke',
+      icon: 'fa-times',
+      class: 'btn-sm btn-outline-danger',
+      callback: (session: Session) => this.revoke(session)
+    }
+  ];
 
   constructor(private sessionService: SessionService) {}
 
@@ -25,6 +55,8 @@ export class SessionsComponent implements OnInit {
     this.sessionService.getSessions().subscribe({
       next: s => {
         this.sessions = s;
+        this.totalResults = s.length;
+        this.updatePagedSessions();
         this.loading = false;
       },
       error: () => {
@@ -33,10 +65,28 @@ export class SessionsComponent implements OnInit {
     });
   }
 
+  updatePagedSessions(): void {
+    const start = (this.page - 1) * this.pageSize;
+    this.pagedSessions = this.sessions.slice(start, start + this.pageSize);
+  }
+
+  onPageChange(newPage: number): void {
+    this.page = newPage;
+    this.updatePagedSessions();
+  }
+
+  onPageSizeChange(newSize: number): void {
+    this.pageSize = newSize;
+    this.page = 1;
+    this.updatePagedSessions();
+  }
+
   revoke(session: Session): void {
     this.sessionService.revokeSession(session.id).subscribe({
       next: () => {
         this.sessions = this.sessions.filter(x => x.id !== session.id);
+        this.totalResults = this.sessions.length;
+        this.updatePagedSessions();
       }
     });
   }


### PR DESCRIPTION
## Summary
- display sessions in reusable table component
- show country, city, agent, and device info
- add paging controls and revoke action

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: process stuck generating browser bundles)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a5dca514832780ed9f43dabe3bb1