### PR TITLE
Remove refresh token absolute expiry

### DIFF
--- a/api/Avancira.Infrastructure/Identity/Tokens/RefreshToken.cs
+++ b/api/Avancira.Infrastructure/Identity/Tokens/RefreshToken.cs
@@ -9,7 +9,6 @@ public class RefreshToken
     public Guid SessionId { get; set; }
     public Guid? RotatedFromId { get; set; }
     public DateTime CreatedUtc { get; set; }
-    public DateTime AbsoluteExpiryUtc { get; set; }
     public DateTime? RevokedUtc { get; set; }
 
     public Session Session { get; set; } = default!;

--- a/api/Avancira.Infrastructure/Identity/Tokens/TokenCleanupService.cs
+++ b/api/Avancira.Infrastructure/Identity/Tokens/TokenCleanupService.cs
@@ -27,7 +27,8 @@ public class TokenCleanupService
         var threshold = now.AddDays(-_options.RetentionDays);
 
         var tokens = await _dbContext.RefreshTokens
-            .Where(t => (t.RevokedUtc != null && t.RevokedUtc <= threshold) || t.AbsoluteExpiryUtc <= threshold)
+            .Include(t => t.Session)
+            .Where(t => (t.RevokedUtc != null && t.RevokedUtc <= threshold) || t.Session.AbsoluteExpiryUtc <= threshold)
             .ToListAsync();
 
         if (tokens.Count == 0)

--- a/api/Avancira.Infrastructure/Persistence/Configurations/RefreshTokenConfiguration.cs
+++ b/api/Avancira.Infrastructure/Persistence/Configurations/RefreshTokenConfiguration.cs
@@ -14,13 +14,11 @@ public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
 
         builder.Property(t => t.TokenHash).IsRequired();
         builder.Property(t => t.CreatedUtc).IsRequired();
-        builder.Property(t => t.AbsoluteExpiryUtc).IsRequired();
         builder.Property(t => t.RevokedUtc);
 
         builder.HasIndex(t => t.SessionId);
         builder.HasIndex(t => t.RotatedFromId).IsUnique(false);
         builder.HasIndex(t => t.CreatedUtc);
-        builder.HasIndex(t => t.AbsoluteExpiryUtc);
         builder.HasIndex(t => t.RevokedUtc);
 
         builder.HasOne(t => t.Session)

--- a/api/Avancira.Migrations/Migrations/20250703000000_RemoveRefreshTokenAbsoluteExpiryUtc.cs
+++ b/api/Avancira.Migrations/Migrations/20250703000000_RemoveRefreshTokenAbsoluteExpiryUtc.cs
@@ -1,0 +1,44 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Avancira.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Avancira.Migrations.Migrations
+{
+    [DbContext(typeof(AvanciraDbContext))]
+    [Migration("20250703000000_RemoveRefreshTokenAbsoluteExpiryUtc")]
+    public class RemoveRefreshTokenAbsoluteExpiryUtc : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_RefreshTokens_AbsoluteExpiryUtc",
+                schema: "identity",
+                table: "RefreshTokens");
+
+            migrationBuilder.DropColumn(
+                name: "AbsoluteExpiryUtc",
+                schema: "identity",
+                table: "RefreshTokens");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "AbsoluteExpiryUtc",
+                schema: "identity",
+                table: "RefreshTokens",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RefreshTokens_AbsoluteExpiryUtc",
+                schema: "identity",
+                table: "RefreshTokens",
+                column: "AbsoluteExpiryUtc");
+        }
+    }
+}
+

--- a/api/Avancira.Migrations/Migrations/AvanciraDbContextModelSnapshot.cs
+++ b/api/Avancira.Migrations/Migrations/AvanciraDbContextModelSnapshot.cs
@@ -88,9 +88,6 @@ namespace Avancira.Migrations.Migrations
                     b.Property<DateTime>("CreatedUtc")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<DateTime>("AbsoluteExpiryUtc")
-                        .HasColumnType("timestamp with time zone");
-
                     b.Property<DateTime?>("RevokedUtc")
                         .HasColumnType("timestamp with time zone");
 
@@ -107,8 +104,6 @@ namespace Avancira.Migrations.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("CreatedUtc");
-
-                    b.HasIndex("AbsoluteExpiryUtc");
 
                     b.HasIndex("RevokedUtc");
 


### PR DESCRIPTION
## Summary
- drop AbsoluteExpiryUtc field from refresh tokens and rely on session expiry
- update token generation/cleanup logic to use session AbsoluteExpiryUtc
- add migration to remove column and index

## Testing
- `dotnet test api/Avancira.API.Tests/Avancira.API.Tests.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b702eb948327b2111c092338b50a