### PR TITLE
Adjust password reset endpoints

### DIFF
--- a/Frontend.Angular/src/app/components/profile-details/profile-details.component.ts
+++ b/Frontend.Angular/src/app/components/profile-details/profile-details.component.ts
@@ -149,7 +149,7 @@ export class ProfileDetailsComponent implements OnInit {
   // 6. Account Management
   changePassword(): void {
     if (this.profile?.email) {
-      this.userService.requestPasswordReset({ email: this.profile.email }).subscribe({
+      this.userService.requestPasswordReset(this.profile.email).subscribe({
         next: () => {
           this.alertService.successAlert('Password reset request has been sent to your email.', 'Success');
         },

--- a/Frontend.Angular/src/app/pages/reset-password/reset-password.component.ts
+++ b/Frontend.Angular/src/app/pages/reset-password/reset-password.component.ts
@@ -62,7 +62,7 @@ export class ResetPasswordComponent implements OnInit {
     const resetData = {
       token: this.token,
       email: this.email,
-      newPassword: this.resetPasswordForm.value.newPassword
+      password: this.resetPasswordForm.value.newPassword
     };
 
     this.userService.resetPassword(resetData).subscribe({

--- a/Frontend.Angular/src/app/services/user.service.ts
+++ b/Frontend.Angular/src/app/services/user.service.ts
@@ -208,11 +208,11 @@ export class UserService {
   }
 
   requestPasswordReset(email: string): Observable<void> {
-    return this.http.put<void>(`${this.apiUrl}/request-reset-password`, { email: email });
+    return this.http.post<void>(`${this.apiUrl}/forgot-password`, { email });
   }
 
-  resetPassword(data: { token: string; newPassword: string }): Observable<void> {
-    return this.http.put<void>(`${this.apiUrl}/reset-password`, data);
+  resetPassword(data: { email: string; password: string; token: string }): Observable<void> {
+    return this.http.post<void>(`${this.apiUrl}/reset-password`, data);
   }
 
   submitDiploma(diplomaFile: File): Observable<void> {


### PR DESCRIPTION
## Summary
- Use `POST /forgot-password` with `{ email }` for password reset requests
- Update `POST /reset-password` payload to include `{ email, password, token }`
- Align components with new password reset method signatures

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: export errors in various components)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c6883a808327b07df1a74122f26f