### PR TITLE
fix: handle reset password redirection

### DIFF
--- a/Frontend.Angular/src/app/pages/reset-password/reset-password.component.ts
+++ b/Frontend.Angular/src/app/pages/reset-password/reset-password.component.ts
@@ -61,23 +61,25 @@ export class ResetPasswordComponent implements OnInit {
 
     this.isSubmitting = true;
     const resetData: ResetPasswordRequest = {
-      token: this.token,
       email: this.email,
-      password: this.resetPasswordForm.value.newPassword
+      password: this.resetPasswordForm.value.newPassword,
+      token: this.token,
     };
 
     this.userService.resetPassword(resetData).subscribe({
       next: () => {
         this.successMessage = 'Your password has been reset successfully!';
+        this.errorMessage = '';
         this.isSubmitting = false;
+        this.resetPasswordForm.reset();
         setTimeout(() => {
-          this.router.navigate(['/login']);
+          this.router.navigate(['/signin']);
         }, 3000);
       },
       error: (err) => {
         this.errorMessage = err.error.message || 'Failed to reset the password.';
         this.isSubmitting = false;
-      }
+      },
     });
   }
 }


### PR DESCRIPTION
## Summary
- send email, new password, and token to reset password endpoint
- clear form, show success message, and redirect to sign-in after reset

## Testing
- `CI=true npm test -- --watch=false` *(fails: Found 1 load error in karma)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cef347948327b2d3fcbaee575c6d