### PR TITLE
fix: correct forgot password route path

### DIFF
--- a/Frontend.Angular/src/app/app.routes.ts
+++ b/Frontend.Angular/src/app/app.routes.ts
@@ -31,7 +31,7 @@ export const routes: Routes = [
   { path: 'video-call-window', component: VideoCallWindowComponent },
   { path: 'signup', component: SignupComponent },
   { path: 'signin', component: SigninComponent },
-  { path: 'forget-password', component: ForgotPasswordComponent },
+  { path: 'forgot-password', component: ForgotPasswordComponent },
   { path: 'reset-password', component: ResetPasswordComponent },
   { path: 'confirm-email', component: ConfirmEmailComponent },
   { path: 'complete-registration', component: CompleteRegistrationComponent },


### PR DESCRIPTION
## Summary
- fix route path from `forget-password` to `forgot-password`

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: Karma load errors)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d81693548327ae34e59db3553387