### PR TITLE
feat: enforce password complexity on reset

### DIFF
--- a/api/Avancira.API.Tests/ResetPasswordValidatorTests.cs
+++ b/api/Avancira.API.Tests/ResetPasswordValidatorTests.cs
@@ -1,0 +1,43 @@
+using Avancira.Application.Identity.Users.Dtos;
+using Avancira.Application.Identity.Users.Validators;
+using FluentValidation.TestHelper;
+using Xunit;
+
+public class ResetPasswordValidatorTests
+{
+    private readonly ResetPasswordValidator _validator = new();
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("short")]
+    [InlineData("alllowercase1!")]
+    [InlineData("ALLUPPERCASE1!")]
+    [InlineData("NoDigits!")]
+    [InlineData("NoSymbols1")]
+    public void Validator_RejectsWeakPasswords(string password)
+    {
+        var dto = new ResetPasswordDto
+        {
+            Email = "user@example.com",
+            Password = password,
+            Token = "token"
+        };
+
+        var result = _validator.TestValidate(dto);
+        result.ShouldHaveValidationErrorFor(x => x.Password);
+    }
+
+    [Fact]
+    public void Validator_AcceptsStrongPassword()
+    {
+        var dto = new ResetPasswordDto
+        {
+            Email = "user@example.com",
+            Password = "Str0ng!Pass",
+            Token = "token"
+        };
+
+        var result = _validator.TestValidate(dto);
+        result.ShouldNotHaveValidationErrorFor(x => x.Password);
+    }
+}

--- a/api/Avancira.Application/Identity/Users/Validators/ResetPasswordValidator.cs
+++ b/api/Avancira.Application/Identity/Users/Validators/ResetPasswordValidator.cs
@@ -6,8 +6,22 @@ public class ResetPasswordValidator : AbstractValidator<ResetPasswordDto>
 {
     public ResetPasswordValidator()
     {
-        RuleFor(x => x.Email).NotEmpty().EmailAddress();
-        RuleFor(x => x.Password).NotEmpty();
+        RuleFor(x => x.Email)
+            .NotEmpty()
+            .EmailAddress();
+
+        RuleFor(x => x.Password)
+            .NotEmpty()
+            .MinimumLength(6)
+            .Matches("[A-Z]")
+                .WithMessage("Password must contain at least one uppercase letter.")
+            .Matches("[a-z]")
+                .WithMessage("Password must contain at least one lowercase letter.")
+            .Matches("[0-9]")
+                .WithMessage("Password must contain at least one digit.")
+            .Matches("[^a-zA-Z0-9]")
+                .WithMessage("Password must contain at least one non-alphanumeric character.");
+
         RuleFor(x => x.Token).NotEmpty();
     }
 }


### PR DESCRIPTION
## Summary
- require strong passwords during reset
- add validator tests for weak passwords

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a5dfab05988327bc29d96dcfb120ae