### PR TITLE
Handle password reset errors in SigninComponent

### DIFF
--- a/Frontend.Angular/src/app/pages/signin/signin.component.ts
+++ b/Frontend.Angular/src/app/pages/signin/signin.component.ts
@@ -143,12 +143,21 @@ export class SigninComponent implements OnInit {
     );
 
     if (email) {
-      this.user.requestPasswordReset(email).subscribe();
-      this.alert.successAlert(
-        'Check your inbox',
-        'We’ve sent a reset link to your email.',
-        'Return to login'
-      );
+      this.user.requestPasswordReset(email).subscribe({
+        next: () =>
+          this.alert.successAlert(
+            'Check your inbox',
+            'We’ve sent a reset link to your email.',
+            'Return to login'
+          ),
+        error: (err) => {
+          console.error('Password reset request failed:', err);
+          this.toastr.error(
+            'Failed to send reset link. Please try again.',
+            'Error'
+          );
+        },
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary
- improve password reset flow in SigninComponent
- show success only after API success and notify on failures

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: export 'DiplomaStatus' not found in '../../models/user')*


------
https://chatgpt.com/codex/tasks/task_e_68a5e668223c8327bbb5b593179ab1d2