### PR TITLE
Handle missing token in reset password

### DIFF
--- a/Frontend.Angular/src/app/pages/reset-password/reset-password.component.html
+++ b/Frontend.Angular/src/app/pages/reset-password/reset-password.component.html
@@ -1,9 +1,9 @@
 <div class="reset-password-container">
-    <h2>Reset Your Password</h2>
+    <h2 *ngIf="!formDisabled">Reset Your Password</h2>
     <p *ngIf="errorMessage" class="error-message">{{ errorMessage }}</p>
     <p *ngIf="successMessage" class="success-message">{{ successMessage }}</p>
-  
-    <form [formGroup]="resetPasswordForm" (ngSubmit)="resetPassword()" *ngIf="!successMessage">
+
+    <form [formGroup]="resetPasswordForm" (ngSubmit)="resetPassword()" *ngIf="!successMessage && !formDisabled">
       <div class="form-group">
         <label for="newPassword">New Password</label>
         <input

--- a/Frontend.Angular/src/app/pages/reset-password/reset-password.component.ts
+++ b/Frontend.Angular/src/app/pages/reset-password/reset-password.component.ts
@@ -19,6 +19,7 @@ export class ResetPasswordComponent implements OnInit {
   isSubmitting: boolean = false;
   successMessage: string = '';
   errorMessage: string = '';
+  formDisabled: boolean = false;
 
   constructor(
     private route: ActivatedRoute,
@@ -37,9 +38,11 @@ export class ResetPasswordComponent implements OnInit {
     this.route.queryParams.subscribe(params => {
       this.token = params['token'] || '';
       this.email = params['email'] || '';
-      
+
       if (!this.token || !this.email) {
         this.errorMessage = 'Invalid or missing reset token or email.';
+        this.formDisabled = true;
+        this.resetPasswordForm.disable();
         return;
       }
       


### PR DESCRIPTION
## Summary
- disable reset password form when token or email is missing
- show only error message when form is disabled

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: export/module not found errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e9e11c7c8327aef4defedaf8a90e