### PR TITLE
Add confirm password validation to reset password flow

### DIFF
--- a/Frontend.Angular/src/app/models/reset-password-request.ts
+++ b/Frontend.Angular/src/app/models/reset-password-request.ts
@@ -1,5 +1,6 @@
 export interface ResetPasswordRequest {
   email: string;
   password: string;
+  confirmPassword: string;
   token: string;
 }

--- a/Frontend.Angular/src/app/pages/reset-password/reset-password.component.ts
+++ b/Frontend.Angular/src/app/pages/reset-password/reset-password.component.ts
@@ -66,6 +66,7 @@ export class ResetPasswordComponent implements OnInit {
     const resetData: ResetPasswordRequest = {
       email: this.email,
       password: this.resetPasswordForm.value.newPassword,
+      confirmPassword: this.resetPasswordForm.value.confirmPassword,
       token: this.token,
     };
 

--- a/Frontend.Angular/src/app/services/user.service.ts
+++ b/Frontend.Angular/src/app/services/user.service.ts
@@ -213,7 +213,12 @@ export class UserService {
   }
 
   resetPassword(data: ResetPasswordRequest): Observable<void> {
-    return this.http.post<void>(`${this.apiUrl}/reset-password`, data);
+    return this.http.post<void>(`${this.apiUrl}/reset-password`, {
+      email: data.email,
+      password: data.password,
+      confirmPassword: data.confirmPassword,
+      token: data.token,
+    });
   }
 
   submitDiploma(diplomaFile: File): Observable<void> {

--- a/api/Avancira.Application/Identity/Users/Dtos/ResetPasswordDto.cs
+++ b/api/Avancira.Application/Identity/Users/Dtos/ResetPasswordDto.cs
@@ -5,6 +5,8 @@ public class ResetPasswordDto
 
     public string Password { get; set; } = default!;
 
+    public string ConfirmPassword { get; set; } = default!;
+
     public string Token { get; set; } = default!;
 }
 

--- a/api/Avancira.Application/Identity/Users/Validators/ResetPasswordValidator.cs
+++ b/api/Avancira.Application/Identity/Users/Validators/ResetPasswordValidator.cs
@@ -22,6 +22,11 @@ public class ResetPasswordValidator : AbstractValidator<ResetPasswordDto>
             .Matches("[^a-zA-Z0-9]")
                 .WithMessage("Password must contain at least one non-alphanumeric character.");
 
+        RuleFor(x => x.ConfirmPassword)
+            .NotEmpty()
+            .Equal(x => x.Password)
+                .WithMessage("Passwords do not match.");
+
         RuleFor(x => x.Token).NotEmpty();
     }
 }

--- a/api/Avancira.Infrastructure/Identity/Users/Services/UserService.Password.cs
+++ b/api/Avancira.Infrastructure/Identity/Users/Services/UserService.Password.cs
@@ -63,6 +63,11 @@ internal sealed partial class UserService
         if (request is null || string.IsNullOrWhiteSpace(request.Email) || string.IsNullOrWhiteSpace(request.Token))
             throw new AvanciraException("Invalid password reset request.");
 
+        if (string.IsNullOrWhiteSpace(request.Password) ||
+            string.IsNullOrWhiteSpace(request.ConfirmPassword) ||
+            request.Password != request.ConfirmPassword)
+            throw new AvanciraException("Passwords do not match.");
+
         const string invalidRequestMessage = "Invalid password reset request.";
         const string invalidTokenMessage = "Invalid password reset token.";
 


### PR DESCRIPTION
## Summary
- add ConfirmPassword field to reset password DTO
- validate ConfirmPassword matches Password in API layer
- send and handle confirmPassword on Angular reset password flow

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm test` *(fails: module not found and build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ed01e63083278c29bd0dccc5c016