### PR TITLE
Use finalize for password reset cleanup

### DIFF
--- a/Frontend.Angular/src/app/pages/forgot-password/forgot-password.component.ts
+++ b/Frontend.Angular/src/app/pages/forgot-password/forgot-password.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { RouterModule } from '@angular/router';
+import { finalize } from 'rxjs/operators';
 
 import { UserService } from '../../services/user.service';
 
@@ -31,18 +32,19 @@ export class ForgotPasswordComponent {
     this.isSubmitting = true;
     const email = this.forgotPasswordForm.value.email;
 
-    this.userService.requestPasswordReset(email).subscribe({
-      next: () => {
-        this.successMessage = 'A password reset link has been sent to your email.';
-        this.errorMessage = '';
-        this.isSubmitting = false;
-      },
-      error: (err) => {
-        this.errorMessage = err?.error?.message || 'Unable to process password reset request.';
-        this.successMessage = '';
-        this.isSubmitting = false;
-      }
-    });
+    this.userService
+      .requestPasswordReset(email)
+      .pipe(finalize(() => (this.isSubmitting = false)))
+      .subscribe({
+        next: () => {
+          this.successMessage = 'A password reset link has been sent to your email.';
+          this.errorMessage = '';
+        },
+        error: (err) => {
+          this.errorMessage = err?.error?.message || 'Unable to process password reset request.';
+          this.successMessage = '';
+        }
+      });
   }
 }
 

--- a/Frontend.Angular/src/app/pages/reset-password/reset-password.component.ts
+++ b/Frontend.Angular/src/app/pages/reset-password/reset-password.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { finalize } from 'rxjs/operators';
 
 import { UserService } from '../../services/user.service';
 import { ResetPasswordRequest } from '../../models/reset-password-request';
@@ -94,20 +95,21 @@ export class ResetPasswordComponent implements OnInit {
       token: this.token,
     };
 
-    this.userService.resetPassword(resetData).subscribe({
-      next: () => {
-        this.successMessage = 'Your password has been reset successfully!';
-        this.errorMessage = '';
-        this.isSubmitting = false;
-        this.resetPasswordForm.reset();
-        setTimeout(() => {
-          this.router.navigate(['/signin']);
-        }, 3000);
-      },
-      error: (err) => {
-        this.errorMessage = err.error.message || 'Failed to reset the password.';
-        this.isSubmitting = false;
-      },
-    });
+    this.userService
+      .resetPassword(resetData)
+      .pipe(finalize(() => (this.isSubmitting = false)))
+      .subscribe({
+        next: () => {
+          this.successMessage = 'Your password has been reset successfully!';
+          this.errorMessage = '';
+          this.resetPasswordForm.reset();
+          setTimeout(() => {
+            this.router.navigate(['/signin']);
+          }, 3000);
+        },
+        error: (err) => {
+          this.errorMessage = err.error.message || 'Failed to reset the password.';
+        },
+      });
   }
 }


### PR DESCRIPTION
## Summary
- use `finalize` operator to reset submitting state in forgot-password and reset-password components
- remove redundant `isSubmitting` resets from success and error handlers

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Error: Found 1 load error)*
- `npm run lint` *(fails: missing script lint)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f3a23b3c83278a948565e9f67a30