### PR TITLE
Use user ID for password reset flow

### DIFF
--- a/Frontend.Angular/src/app/models/reset-password-request.ts
+++ b/Frontend.Angular/src/app/models/reset-password-request.ts
@@ -1,5 +1,5 @@
 export interface ResetPasswordRequest {
-  email: string;
+  userId: string;
   password: string;
   confirmPassword: string;
   token: string;

--- a/Frontend.Angular/src/app/pages/reset-password/reset-password.component.ts
+++ b/Frontend.Angular/src/app/pages/reset-password/reset-password.component.ts
@@ -16,7 +16,7 @@ import { ResetPasswordRequest } from '../../models/reset-password-request';
 export class ResetPasswordComponent implements OnInit {
   resetPasswordForm: FormGroup;
   token: string = '';
-  email: string = '';
+  userId: string = '';
   isSubmitting: boolean = false;
   successMessage: string = '';
   errorMessage: string = '';
@@ -35,7 +35,6 @@ export class ResetPasswordComponent implements OnInit {
     private router: Router
   ) {
     this.resetPasswordForm = this.fb.group({
-      email: [{ value: '', disabled: true }, [Validators.required, Validators.email]],
       newPassword: [
         '',
         [
@@ -62,17 +61,14 @@ export class ResetPasswordComponent implements OnInit {
   ngOnInit(): void {
     this.route.queryParams.subscribe(params => {
       this.token = params['token'] || '';
-      this.email = params['email'] || '';
+      this.userId = params['userId'] || '';
 
-      if (!this.token || !this.email) {
-        this.errorMessage = 'Invalid or missing reset token or email.';
+      if (!this.token || !this.userId) {
+        this.errorMessage = 'Invalid or missing reset token or user identifier.';
         this.formDisabled = true;
         this.resetPasswordForm.disable();
         return;
       }
-      
-      // Set the email value in the form
-      this.resetPasswordForm.patchValue({ email: this.email });
     });
   }
 
@@ -89,7 +85,7 @@ export class ResetPasswordComponent implements OnInit {
 
     this.isSubmitting = true;
     const resetData: ResetPasswordRequest = {
-      email: this.email,
+      userId: this.userId,
       password: this.resetPasswordForm.value.newPassword,
       confirmPassword: this.resetPasswordForm.value.confirmPassword,
       token: this.token,

--- a/Frontend.Angular/src/app/services/user.service.ts
+++ b/Frontend.Angular/src/app/services/user.service.ts
@@ -214,7 +214,7 @@ export class UserService {
 
   resetPassword(data: ResetPasswordRequest): Observable<void> {
     return this.http.post<void>(`${this.apiUrl}/reset-password`, {
-      email: data.email,
+      userId: data.userId,
       password: data.password,
       confirmPassword: data.confirmPassword,
       token: data.token,

--- a/api/Avancira.API.Tests/ResetPasswordValidatorTests.cs
+++ b/api/Avancira.API.Tests/ResetPasswordValidatorTests.cs
@@ -19,7 +19,7 @@ public class ResetPasswordValidatorTests
     {
         var dto = new ResetPasswordDto
         {
-            Email = "user@example.com",
+            UserId = "user-id",
             Password = password,
             Token = "token"
         };
@@ -33,7 +33,7 @@ public class ResetPasswordValidatorTests
     {
         var dto = new ResetPasswordDto
         {
-            Email = "user@example.com",
+            UserId = "user-id",
             Password = "Str0ng!Pass",
             Token = "token"
         };

--- a/api/Avancira.Application/Identity/Users/Dtos/ResetPasswordDto.cs
+++ b/api/Avancira.Application/Identity/Users/Dtos/ResetPasswordDto.cs
@@ -1,7 +1,7 @@
 ﻿namespace Avancira.Application.Identity.Users.Dtos;
 public class ResetPasswordDto
 {
-    public string Email { get; set; } = default!;
+    public string UserId { get; set; } = default!;
 
     public string Password { get; set; } = default!;
 

--- a/api/Avancira.Application/Identity/Users/Validators/ResetPasswordValidator.cs
+++ b/api/Avancira.Application/Identity/Users/Validators/ResetPasswordValidator.cs
@@ -6,9 +6,8 @@ public class ResetPasswordValidator : AbstractValidator<ResetPasswordDto>
 {
     public ResetPasswordValidator()
     {
-        RuleFor(x => x.Email)
-            .NotEmpty()
-            .EmailAddress();
+        RuleFor(x => x.UserId)
+            .NotEmpty();
 
         RuleFor(x => x.Password)
             .NotEmpty()

--- a/api/Avancira.Infrastructure/Identity/Users/Services/UserService.Password.cs
+++ b/api/Avancira.Infrastructure/Identity/Users/Services/UserService.Password.cs
@@ -46,7 +46,7 @@ internal sealed partial class UserService
         var encodedToken = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(rawToken));
 
         var sanitizedOrigin = originUri.GetLeftPart(UriPartial.Path).TrimEnd('/');
-        var resetPasswordUri = BuildResetPasswordLink(sanitizedOrigin, request.Email, encodedToken);
+        var resetPasswordUri = BuildResetPasswordLink(sanitizedOrigin, user.Id, encodedToken);
 
         var resetPasswordEvent = new ResetPasswordEvent
         {
@@ -60,7 +60,7 @@ internal sealed partial class UserService
 
     public async Task ResetPasswordAsync(ResetPasswordDto request, CancellationToken cancellationToken)
     {
-        if (request is null || string.IsNullOrWhiteSpace(request.Email) || string.IsNullOrWhiteSpace(request.Token))
+        if (request is null || string.IsNullOrWhiteSpace(request.UserId) || string.IsNullOrWhiteSpace(request.Token))
             throw new AvanciraException("Invalid password reset request.");
 
         if (string.IsNullOrWhiteSpace(request.Password) ||
@@ -71,7 +71,7 @@ internal sealed partial class UserService
         const string invalidRequestMessage = "Invalid password reset request.";
         const string invalidTokenMessage = "Invalid password reset token.";
 
-        var user = await userManager.FindByEmailAsync(request.Email);
+        var user = await userManager.FindByIdAsync(request.UserId);
         if (user == null)
             throw new AvanciraException(invalidRequestMessage);
 
@@ -117,12 +117,12 @@ internal sealed partial class UserService
         await userManager.UpdateSecurityStampAsync(user);
     }
 
-    private static string BuildResetPasswordLink(string origin, string email, string encodedToken)
+    private static string BuildResetPasswordLink(string origin, string userId, string encodedToken)
     {
         var baseUri = origin.TrimEnd('/');
         var endpoint = $"{baseUri}/reset-password";
-        var withEmail = QueryHelpers.AddQueryString(endpoint, "email", email);
-        var withToken = QueryHelpers.AddQueryString(withEmail, "token", encodedToken);
+        var withUserId = QueryHelpers.AddQueryString(endpoint, "userId", userId);
+        var withToken = QueryHelpers.AddQueryString(withUserId, "token", encodedToken);
         return withToken;
     }
 }


### PR DESCRIPTION
## Summary
- Replace email parameter with user ID in reset-password link generation and lookup
- Update DTOs, validators and Angular frontend to send and parse userId instead of email
- Adjust tests for updated password reset validation

## Testing
- `dotnet test` *(failed: command not found)*
- `apt-get update` *(failed: 403 Forbidden)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(failed: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f615d4e48327b310958ec21e0bf5