### PR TITLE
Add rate limiting to password reset endpoints

### DIFF
--- a/api/Avancira.API/Controllers/UsersController.cs
+++ b/api/Avancira.API/Controllers/UsersController.cs
@@ -10,6 +10,7 @@ using Avancira.Domain.Auditing;
 using Avancira.Application.Paging;
 using Avancira.Domain.Common.Exceptions;
 using Avancira.Application.Identity.Users.Abstractions;
+using Microsoft.AspNetCore.RateLimiting;
 
 namespace Avancira.API.Controllers;
 
@@ -133,6 +134,7 @@ public class UsersController : BaseApiController
 
     [HttpPost("reset-password")]
     [AllowAnonymous]
+    [EnableRateLimiting("PasswordResetPolicy")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [SwaggerOperation(OperationId = "ResetPassword")]
     public async Task<IActionResult> ResetPassword([FromBody] ResetPasswordDto command, CancellationToken cancellationToken)
@@ -143,6 +145,7 @@ public class UsersController : BaseApiController
 
     [HttpPost("forgot-password")]
     [AllowAnonymous]
+    [EnableRateLimiting("PasswordResetPolicy")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [SwaggerOperation(OperationId = "ForgotPassword")]
     public async Task<IActionResult> ForgotPassword([FromBody] ForgotPasswordDto command, CancellationToken cancellationToken)

--- a/api/Avancira.API/README.md
+++ b/api/Avancira.API/README.md
@@ -1,0 +1,10 @@
+# Avancira.API
+
+## Rate limiting
+
+The `reset-password` and `forgot-password` endpoints use a fixed window rate limiter.
+
+- **Limit:** 5 requests per 15-minute window per IP address.
+- **Enforcement:** Requests beyond this limit receive HTTP 429 responses.
+- **Monitoring:** Rejected requests are logged, enabling detection of potential abuse.
+


### PR DESCRIPTION
## Summary
- throttle password reset endpoints using fixed window limiter
- log rate limit rejections for monitoring
- document password reset rate limit policy

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository is not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f80553a48327aa23f120bd4b8ad5