### PR TITLE
feat: centralize password complexity validation

### DIFF
--- a/Frontend.Angular/src/app/pages/reset-password/reset-password.component.html
+++ b/Frontend.Angular/src/app/pages/reset-password/reset-password.component.html
@@ -19,36 +19,16 @@
           <span *ngIf="newPasswordControl?.errors?.['minlength']">
             Password must be at least 8 characters.
           </span>
-          <span
-            *ngIf="
-              newPasswordControl?.hasError('pattern') &&
-              !uppercasePattern.test(newPasswordControl?.value || '')
-            "
-          >
+          <span *ngIf="newPasswordControl?.errors?.['noUppercase']">
             Password must contain at least one uppercase letter.
           </span>
-          <span
-            *ngIf="
-              newPasswordControl?.hasError('pattern') &&
-              !lowercasePattern.test(newPasswordControl?.value || '')
-            "
-          >
+          <span *ngIf="newPasswordControl?.errors?.['noLowercase']">
             Password must contain at least one lowercase letter.
           </span>
-          <span
-            *ngIf="
-              newPasswordControl?.hasError('pattern') &&
-              !digitPattern.test(newPasswordControl?.value || '')
-            "
-          >
+          <span *ngIf="newPasswordControl?.errors?.['noDigit']">
             Password must contain at least one digit.
           </span>
-          <span
-            *ngIf="
-              newPasswordControl?.hasError('pattern') &&
-              !symbolPattern.test(newPasswordControl?.value || '')
-            "
-          >
+          <span *ngIf="newPasswordControl?.errors?.['noNonAlphanumeric']">
             Password must contain at least one non-alphanumeric character.
           </span>
         </div>

--- a/Frontend.Angular/src/app/pages/reset-password/reset-password.component.ts
+++ b/Frontend.Angular/src/app/pages/reset-password/reset-password.component.ts
@@ -4,8 +4,9 @@ import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } 
 import { ActivatedRoute, Router } from '@angular/router';
 import { finalize } from 'rxjs/operators';
 
-import { UserService } from '../../services/user.service';
 import { ResetPasswordRequest } from '../../models/reset-password-request';
+import { UserService } from '../../services/user.service';
+import { passwordComplexityValidator } from '../../validators/password.validators';
 
 @Component({
   selector: 'app-reset-password',
@@ -22,12 +23,6 @@ export class ResetPasswordComponent implements OnInit {
   errorMessage: string = '';
   formDisabled: boolean = false;
 
-  // Password complexity patterns mirroring backend requirements
-  uppercasePattern = /[A-Z]/;
-  lowercasePattern = /[a-z]/;
-  digitPattern = /[0-9]/;
-  symbolPattern = /[^a-zA-Z0-9]/;
-
   constructor(
     private route: ActivatedRoute,
     private fb: FormBuilder,
@@ -40,10 +35,7 @@ export class ResetPasswordComponent implements OnInit {
         [
           Validators.required,
           Validators.minLength(8),
-          Validators.pattern(this.uppercasePattern),
-          Validators.pattern(this.lowercasePattern),
-          Validators.pattern(this.digitPattern),
-          Validators.pattern(this.symbolPattern),
+          passwordComplexityValidator(),
         ],
       ],
       confirmPassword: ['', [Validators.required]],

--- a/Frontend.Angular/src/app/pages/signup/signup.component.html
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.html
@@ -59,7 +59,7 @@
               </span>
               <span class="text-danger"
                 *ngIf="signupForm.get('password')?.errors?.['minlength'] && signupForm.get('password')?.touched">
-                Password must be at least 6 characters long.
+                Password must be at least 8 characters long.
               </span>
               <span class="text-danger"
                 *ngIf="signupForm.get('password')?.errors?.['noNonAlphanumeric'] && signupForm.get('password')?.touched">
@@ -72,6 +72,10 @@
               <span class="text-danger"
                 *ngIf="signupForm.get('password')?.errors?.['noUppercase'] && signupForm.get('password')?.touched">
                 Password must contain at least one uppercase letter.
+              </span>
+              <span class="text-danger"
+                *ngIf="signupForm.get('password')?.errors?.['noDigit'] && signupForm.get('password')?.touched">
+                Password must contain at least one digit.
               </span>
 
 

--- a/Frontend.Angular/src/app/pages/signup/signup.component.ts
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.ts
@@ -17,6 +17,7 @@ import { ConfigService } from '../../services/config.service';
 import { GoogleAuthService } from '../../services/google-auth.service';
 import { SpinnerService } from '../../services/spinner.service';
 import { ValidatorService } from '../../validators/password-validator.service';
+import { passwordComplexityValidator } from '../../validators/password.validators';
 
 @Component({
   selector: 'app-signup',
@@ -49,10 +50,8 @@ export class SignupComponent implements OnInit {
         '',
         [
           Validators.required,
-          Validators.minLength(6),
-          ValidatorService.hasLowercase(),
-          ValidatorService.hasUppercase(),
-          ValidatorService.hasNonAlphanumeric(),
+          Validators.minLength(8),
+          passwordComplexityValidator(),
         ],
       ],
       verifyPassword: ['', [Validators.required, ValidatorService.matchesPassword('password')]],

--- a/Frontend.Angular/src/app/validators/password-validator.service.ts
+++ b/Frontend.Angular/src/app/validators/password-validator.service.ts
@@ -2,39 +2,6 @@ import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 
 export class ValidatorService {
 
-  // Validator for non-alphanumeric characters
-  static hasNonAlphanumeric(): ValidatorFn {
-    return (control: AbstractControl): ValidationErrors | null => {
-      const value = control.value;
-      if (value && !/[^\w\s]/.test(value)) {
-        return { noNonAlphanumeric: true };
-      }
-      return null;
-    };
-  }
-
-  // Validator for at least one lowercase letter
-  static hasLowercase(): ValidatorFn {
-    return (control: AbstractControl): ValidationErrors | null => {
-      const value = control.value;
-      if (value && !/[a-z]/.test(value)) {
-        return { noLowercase: true };
-      }
-      return null;
-    };
-  }
-
-  // Validator for at least one uppercase letter
-  static hasUppercase(): ValidatorFn {
-    return (control: AbstractControl): ValidationErrors | null => {
-      const value = control.value;
-      if (value && !/[A-Z]/.test(value)) {
-        return { noUppercase: true };
-      }
-      return null;
-    };
-  }
-
   static matchesPassword(passwordField: string): ValidatorFn {
     return (control: AbstractControl): ValidationErrors | null => {
       if (!control.parent) {

--- a/Frontend.Angular/src/app/validators/password.validators.ts
+++ b/Frontend.Angular/src/app/validators/password.validators.ts
@@ -1,0 +1,35 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+export const UPPERCASE_PATTERN = /[A-Z]/;
+export const LOWERCASE_PATTERN = /[a-z]/;
+export const DIGIT_PATTERN = /[0-9]/;
+export const SYMBOL_PATTERN = /[^a-zA-Z0-9]/;
+
+/**
+ * Validates that a control's value meets common password complexity rules.
+ * Returns individual error flags for missing character classes.
+ */
+export function passwordComplexityValidator(): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const value = control.value as string;
+    if (!value) {
+      return null;
+    }
+
+    const errors: ValidationErrors = {};
+    if (!UPPERCASE_PATTERN.test(value)) {
+      errors['noUppercase'] = true;
+    }
+    if (!LOWERCASE_PATTERN.test(value)) {
+      errors['noLowercase'] = true;
+    }
+    if (!DIGIT_PATTERN.test(value)) {
+      errors['noDigit'] = true;
+    }
+    if (!SYMBOL_PATTERN.test(value)) {
+      errors['noNonAlphanumeric'] = true;
+    }
+
+    return Object.keys(errors).length ? errors : null;
+  };
+}


### PR DESCRIPTION
## Summary
- add shared password complexity validator
- apply unified complexity rules to reset and signup forms
- simplify password match validator service

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Module not found & stylesheet errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a60cded8cc8327a2f7615a049cb317