### PR TITLE
feat: add form-level password match validator

### DIFF
--- a/Frontend.Angular/src/app/pages/reset-password/reset-password.component.html
+++ b/Frontend.Angular/src/app/pages/reset-password/reset-password.component.html
@@ -42,9 +42,14 @@
           formControlName="confirmPassword"
           placeholder="Confirm your password"
         />
-        <span *ngIf="confirmPasswordControl?.invalid && confirmPasswordControl?.touched">
-          Confirmation is required.
-        </span>
+        <div *ngIf="confirmPasswordControl?.touched">
+          <span *ngIf="confirmPasswordControl?.errors?.['required']">
+            Confirmation is required.
+          </span>
+          <span *ngIf="resetPasswordForm.errors?.['passwordsMismatch']">
+            Passwords do not match.
+          </span>
+        </div>
       </div>
   
       <button type="submit" [disabled]="isSubmitting">Reset Password</button>

--- a/Frontend.Angular/src/app/pages/reset-password/reset-password.component.spec.ts
+++ b/Frontend.Angular/src/app/pages/reset-password/reset-password.component.spec.ts
@@ -50,4 +50,13 @@ describe('ResetPasswordComponent', () => {
     control.setValue('Str0ng!Pass');
     expect(control.valid).toBeTrue();
   });
+
+  it('should invalidate the form when passwords do not match', () => {
+    const form = component.resetPasswordForm;
+    form.controls['newPassword'].setValue('Str0ng!Pass');
+    form.controls['confirmPassword'].setValue('Different1!');
+    expect(form.valid).toBeFalse();
+    form.controls['confirmPassword'].setValue('Str0ng!Pass');
+    expect(form.valid).toBeTrue();
+  });
 });

--- a/Frontend.Angular/src/app/pages/reset-password/reset-password.component.ts
+++ b/Frontend.Angular/src/app/pages/reset-password/reset-password.component.ts
@@ -6,7 +6,7 @@ import { finalize } from 'rxjs/operators';
 
 import { ResetPasswordRequest } from '../../models/reset-password-request';
 import { UserService } from '../../services/user.service';
-import { passwordComplexityValidator } from '../../validators/password.validators';
+import { matchPasswords, passwordComplexityValidator } from '../../validators/password.validators';
 
 @Component({
   selector: 'app-reset-password',
@@ -29,17 +29,20 @@ export class ResetPasswordComponent implements OnInit {
     private userService: UserService,
     private router: Router
   ) {
-    this.resetPasswordForm = this.fb.group({
-      newPassword: [
-        '',
-        [
-          Validators.required,
-          Validators.minLength(8),
-          passwordComplexityValidator(),
+    this.resetPasswordForm = this.fb.group(
+      {
+        newPassword: [
+          '',
+          [
+            Validators.required,
+            Validators.minLength(8),
+            passwordComplexityValidator(),
+          ],
         ],
-      ],
-      confirmPassword: ['', [Validators.required]],
-    });
+        confirmPassword: ['', [Validators.required]],
+      },
+      { validators: matchPasswords() }
+    );
   }
 
   get newPasswordControl() {
@@ -66,12 +69,7 @@ export class ResetPasswordComponent implements OnInit {
 
   resetPassword(): void {
     if (this.resetPasswordForm.invalid) {
-      this.errorMessage = 'Please ensure the form is valid.';
-      return;
-    }
-
-    if (this.resetPasswordForm.value.newPassword !== this.resetPasswordForm.value.confirmPassword) {
-      this.errorMessage = 'Passwords do not match.';
+      this.resetPasswordForm.markAllAsTouched();
       return;
     }
 

--- a/Frontend.Angular/src/app/validators/password.validators.ts
+++ b/Frontend.Angular/src/app/validators/password.validators.ts
@@ -33,3 +33,22 @@ export function passwordComplexityValidator(): ValidatorFn {
     return Object.keys(errors).length ? errors : null;
   };
 }
+
+/**
+ * Validates that the `newPassword` and `confirmPassword` controls
+ * within a form group contain identical values.
+ */
+export function matchPasswords(): ValidatorFn {
+  return (group: AbstractControl): ValidationErrors | null => {
+    const newPassword = group.get('newPassword')?.value;
+    const confirmPassword = group.get('confirmPassword')?.value;
+
+    if (!newPassword || !confirmPassword) {
+      return null;
+    }
+
+    return newPassword === confirmPassword
+      ? null
+      : { passwordsMismatch: true };
+  };
+}


### PR DESCRIPTION
## Summary
- add `matchPasswords` validator to ensure `newPassword` and `confirmPassword` match
- apply validator in `ResetPasswordComponent` form initialization and show mismatch errors in template
- add unit test for password mismatch

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless could not run in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a60efa1e508327ba25b62100ae8c75