### PR TITLE
Refactor reset-password query param subscription

### DIFF
--- a/Frontend.Angular/src/app/pages/reset-password/reset-password.component.spec.ts
+++ b/Frontend.Angular/src/app/pages/reset-password/reset-password.component.spec.ts
@@ -1,16 +1,23 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { Subject } from 'rxjs';
 
 import { ResetPasswordComponent } from './reset-password.component';
 
 describe('ResetPasswordComponent', () => {
   let component: ResetPasswordComponent;
   let fixture: ComponentFixture<ResetPasswordComponent>;
+  let queryParamsSubject: Subject<any>;
 
   beforeEach(async () => {
+    queryParamsSubject = new Subject();
+
     await TestBed.configureTestingModule({
-      imports: [ResetPasswordComponent]
-    })
-    .compileComponents();
+      imports: [ResetPasswordComponent],
+      providers: [
+        { provide: ActivatedRoute, useValue: { queryParams: queryParamsSubject.asObservable() } },
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ResetPasswordComponent);
     component = fixture.componentInstance;
@@ -58,5 +65,17 @@ describe('ResetPasswordComponent', () => {
     expect(form.valid).toBeFalse();
     form.controls['confirmPassword'].setValue('Str0ng!Pass');
     expect(form.valid).toBeTrue();
+  });
+
+  it('should unsubscribe from query params on destroy', () => {
+    queryParamsSubject.next({ token: 'first', userId: 'one' });
+    expect(component.token).toBe('first');
+    expect(component.userId).toBe('one');
+
+    component.ngOnDestroy();
+    queryParamsSubject.next({ token: 'second', userId: 'two' });
+
+    expect(component.token).toBe('first');
+    expect(component.userId).toBe('one');
   });
 });


### PR DESCRIPTION
## Summary
- prevent potential memory leaks in ResetPasswordComponent by unsubscribing using `takeUntil` and an `OnDestroy` hook
- extend unit tests to verify the query param subscription completes when the component is destroyed

## Testing
- `npm test -- --include=src/app/pages/reset-password/reset-password.component.spec.ts --watch=false --browsers=ChromeHeadless` *(fails: Module '../../models/user' has no exported member 'DiplomaStatus', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a61d11c480832794a82ae16eaf00bd