### PR TITLE
refactor: use async/await for password flows

### DIFF
--- a/Frontend.Angular/src/app/pages/forgot-password/forgot-password.component.spec.ts
+++ b/Frontend.Angular/src/app/pages/forgot-password/forgot-password.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { ForgotPasswordComponent } from './forgot-password.component';
 import { UserService } from '../../services/user.service';
@@ -26,5 +26,29 @@ describe('ForgotPasswordComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should set success message on successful submit', async () => {
+    component.forgotPasswordForm.setValue({ email: 'test@example.com' });
+
+    await component.onSubmit();
+
+    expect(userServiceSpy.requestPasswordReset).toHaveBeenCalledWith('test@example.com');
+    expect(component.successMessage).toBe('A password reset link has been sent to your email.');
+    expect(component.errorMessage).toBe('');
+    expect(component.isSubmitting).toBeFalse();
+  });
+
+  it('should set error message on failed submit', async () => {
+    userServiceSpy.requestPasswordReset.and.returnValue(
+      throwError(() => ({ error: { message: 'fail' } }))
+    );
+    component.forgotPasswordForm.setValue({ email: 'test@example.com' });
+
+    await component.onSubmit();
+
+    expect(component.errorMessage).toBe('fail');
+    expect(component.successMessage).toBe('');
+    expect(component.isSubmitting).toBeFalse();
   });
 });

--- a/Frontend.Angular/src/app/pages/forgot-password/forgot-password.component.ts
+++ b/Frontend.Angular/src/app/pages/forgot-password/forgot-password.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { finalize } from 'rxjs/operators';
+import { firstValueFrom } from 'rxjs';
 
 import { UserService } from '../../services/user.service';
 
@@ -24,7 +24,7 @@ export class ForgotPasswordComponent {
     });
   }
 
-  onSubmit(): void {
+  async onSubmit(): Promise<void> {
     if (this.forgotPasswordForm.invalid) {
       return;
     }
@@ -32,19 +32,16 @@ export class ForgotPasswordComponent {
     this.isSubmitting = true;
     const email = this.forgotPasswordForm.value.email;
 
-    this.userService
-      .requestPasswordReset(email)
-      .pipe(finalize(() => (this.isSubmitting = false)))
-      .subscribe({
-        next: () => {
-          this.successMessage = 'A password reset link has been sent to your email.';
-          this.errorMessage = '';
-        },
-        error: (err) => {
-          this.errorMessage = err?.error?.message || 'Unable to process password reset request.';
-          this.successMessage = '';
-        }
-      });
+    try {
+      await firstValueFrom(this.userService.requestPasswordReset(email));
+      this.successMessage = 'A password reset link has been sent to your email.';
+      this.errorMessage = '';
+    } catch (err: any) {
+      this.errorMessage = err?.error?.message || 'Unable to process password reset request.';
+      this.successMessage = '';
+    } finally {
+      this.isSubmitting = false;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- refactor forgot and reset password flows to use async/await instead of subscribe/finalize
- handle success and error states with try/catch and isSubmitting toggling
- add unit tests for forgot and reset password components

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Found 1 load error; missing stylesheet imports and module export errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a61f4222908327bd937b76694d7cfd