### PR TITLE
feat: add password reset cooldown timer

### DIFF
--- a/Frontend.Angular/src/app/pages/forgot-password/forgot-password.component.html
+++ b/Frontend.Angular/src/app/pages/forgot-password/forgot-password.component.html
@@ -21,7 +21,9 @@
                         <div class="text-end">
                             <a class="forgot-link" routerLink="/signin">Remember your password?</a>
                         </div>
-                        <button class="btn btn-primary login-btn" type="submit" [disabled]="isSubmitting">Reset Password</button>
+                        <button class="btn btn-primary login-btn" type="submit" [disabled]="isSubmitting || cooldown > 0">
+                            {{ cooldown > 0 ? ('Wait ' + cooldown + 's') : 'Reset Password' }}
+                        </button>
                     </form>
                     <!-- /Forgot Password Form -->
 

--- a/Frontend.Angular/src/app/pages/forgot-password/forgot-password.component.spec.ts
+++ b/Frontend.Angular/src/app/pages/forgot-password/forgot-password.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
 
 import { ForgotPasswordComponent } from './forgot-password.component';
@@ -10,8 +10,9 @@ describe('ForgotPasswordComponent', () => {
   let userServiceSpy: jasmine.SpyObj<UserService>;
 
   beforeEach(async () => {
-    userServiceSpy = jasmine.createSpyObj('UserService', ['requestPasswordReset']);
+    userServiceSpy = jasmine.createSpyObj('UserService', ['requestPasswordReset', 'getRequestPasswordResetCooldown']);
     userServiceSpy.requestPasswordReset.and.returnValue(of(void 0));
+    userServiceSpy.getRequestPasswordResetCooldown.and.returnValue(0);
 
     await TestBed.configureTestingModule({
       imports: [ForgotPasswordComponent],
@@ -51,4 +52,19 @@ describe('ForgotPasswordComponent', () => {
     expect(component.successMessage).toBe('');
     expect(component.isSubmitting).toBeFalse();
   });
+
+  it('should disable form if cooldown active on init', fakeAsync(() => {
+    userServiceSpy.getRequestPasswordResetCooldown.and.returnValue(2);
+
+    fixture = TestBed.createComponent(ForgotPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    expect(button.disabled).toBeTrue();
+
+    tick(2000);
+    fixture.detectChanges();
+    expect(button.disabled).toBeFalse();
+  }));
 });

--- a/Frontend.Angular/src/app/pages/forgot-password/forgot-password.e2e-spec.ts
+++ b/Frontend.Angular/src/app/pages/forgot-password/forgot-password.e2e-spec.ts
@@ -1,0 +1,43 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { ForgotPasswordComponent } from './forgot-password.component';
+import { UserService } from '../../services/user.service';
+
+describe('ForgotPasswordComponent e2e', () => {
+  let component: ForgotPasswordComponent;
+  let fixture: ComponentFixture<ForgotPasswordComponent>;
+  let userServiceSpy: jasmine.SpyObj<UserService>;
+
+  beforeEach(async () => {
+    userServiceSpy = jasmine.createSpyObj('UserService', ['requestPasswordReset', 'getRequestPasswordResetCooldown']);
+    userServiceSpy.getRequestPasswordResetCooldown.and.returnValue(0);
+    userServiceSpy.requestPasswordReset.and.callFake(() => {
+      userServiceSpy.getRequestPasswordResetCooldown.and.returnValue(3);
+      return of(void 0);
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [ForgotPasswordComponent],
+      providers: [{ provide: UserService, useValue: userServiceSpy }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ForgotPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('disables the submit button during cooldown after submission', fakeAsync(() => {
+    component.forgotPasswordForm.setValue({ email: 'test@example.com' });
+    component.onSubmit();
+    tick();
+    fixture.detectChanges();
+
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    expect(button.disabled).toBeTrue();
+
+    tick(3000);
+    fixture.detectChanges();
+    expect(button.disabled).toBeFalse();
+  }));
+});


### PR DESCRIPTION
## Summary
- disable forgot-password form while cooldown is active
- show button countdown and re-enable after timer
- add unit and e2e tests for cooldown behaviour

## Testing
- `CI=true npx ng test --watch=false --progress=false` *(fails: Module not found etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a6211942d883279c4b18150f072c49