### PR TITLE
Collect full user details during registration

### DIFF
--- a/Frontend.Angular/src/app/models/register-user-response.ts
+++ b/Frontend.Angular/src/app/models/register-user-response.ts
@@ -1,0 +1,3 @@
+export interface RegisterUserResponseDto {
+  userId: string;
+}

--- a/Frontend.Angular/src/app/pages/signup/signup.component.html
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.html
@@ -13,20 +13,84 @@
 
           <!-- Register Form -->
           <form [formGroup]="signupForm" (ngSubmit)="onSignup()">
-            <!-- <div class="row">
+            <div class="row">
               <div class="col-lg-6">
                 <div class="form-group">
                   <label class="form-control-label">First Name</label>
-                  <input id="first-name" type="text" class="form-control" name="first_name" autofocus="">
+                  <input
+                    id="Input_FirstName"
+                    type="text"
+                    class="form-control"
+                    formControlName="firstName"
+                    [ngClass]="{ 'is-invalid': signupForm.get('firstName')?.invalid && signupForm.get('firstName')?.touched }"
+                  />
+                  <div
+                    class="invalid-feedback"
+                    *ngIf="signupForm.get('firstName')?.errors?.['required'] && signupForm.get('firstName')?.touched"
+                  >
+                    First name is required.
+                  </div>
                 </div>
               </div>
               <div class="col-lg-6">
                 <div class="form-group">
                   <label class="form-control-label">Last Name</label>
-                  <input id="last-name" type="text" class="form-control" name="last_name">
+                  <input
+                    id="Input_LastName"
+                    type="text"
+                    class="form-control"
+                    formControlName="lastName"
+                    [ngClass]="{ 'is-invalid': signupForm.get('lastName')?.invalid && signupForm.get('lastName')?.touched }"
+                  />
+                  <div
+                    class="invalid-feedback"
+                    *ngIf="signupForm.get('lastName')?.errors?.['required'] && signupForm.get('lastName')?.touched"
+                  >
+                    Last name is required.
+                  </div>
                 </div>
               </div>
-            </div> -->
+            </div>
+            <div class="row">
+              <div class="col-lg-6">
+                <div class="form-group">
+                  <label class="form-control-label">Username</label>
+                  <input
+                    id="Input_UserName"
+                    type="text"
+                    class="form-control"
+                    formControlName="userName"
+                    [ngClass]="{ 'is-invalid': signupForm.get('userName')?.invalid && signupForm.get('userName')?.touched }"
+                  />
+                  <div
+                    class="invalid-feedback"
+                    *ngIf="signupForm.get('userName')?.errors?.['required'] && signupForm.get('userName')?.touched"
+                  >
+                    Username is required.
+                  </div>
+                </div>
+              </div>
+              <div class="col-lg-6">
+                <div class="form-group">
+                  <label class="form-control-label">Phone Number</label>
+                  <input
+                    id="Input_PhoneNumber"
+                    type="tel"
+                    class="form-control"
+                    formControlName="phoneNumber"
+                  />
+                </div>
+              </div>
+            </div>
+            <div class="form-group">
+              <label class="form-control-label">Time Zone</label>
+              <input
+                id="Input_TimeZoneId"
+                type="text"
+                class="form-control"
+                formControlName="timeZoneId"
+              />
+            </div>
             <div class="form-group">
               <label class="form-control-label">Email Address</label>
               <input type="email" id="Input_Email" class="form-control" placeholder="Email address"
@@ -92,8 +156,9 @@
                     href="/privacy-policy">Privacy Policy</a> &amp; <a tabindex="-1" href="/terms"> Terms.</a> </label>
               </div>
             </div>
-            <button class="btn btn-primary login-btn" type="submit" [disabled]="signupForm.invalid">Create
-              Account</button>
+            <button class="btn btn-primary login-btn" type="submit" [disabled]="signupForm.invalid || isSubmitting">
+              Create Account
+            </button>
             <!-- Error Message -->
             <div *ngIf="signupError" class="alert alert-danger" role="alert">
               {{ signupError }}

--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -6,7 +6,8 @@ import { catchError, finalize, map, retry, shareReplay, switchMap, take, tap } f
 import { jwtDecode } from 'jwt-decode';
 
 import { environment } from '../environments/environment';
-import { INCLUDE_CREDENTIALS, REQUIRES_AUTH,SKIP_AUTH } from '../interceptors/auth.interceptor';
+import { INCLUDE_CREDENTIALS, REQUIRES_AUTH, SKIP_AUTH } from '../interceptors/auth.interceptor';
+import { RegisterUserResponseDto } from '../models/register-user-response';
 import { UserProfile } from '../models/UserProfile';
 
 interface TokenResponse { token: string; }
@@ -96,6 +97,36 @@ export class AuthService implements OnDestroy {
       switchMap(() => this.http.get<string[]>(`${this.api}/users/permissions`).pipe(catchError(() => of([])))),
       tap(perms => this.patchProfile({ permissions: perms } as Partial<UserProfile>)),
       map(() => { this.setState(AuthStateKind.Authenticated); return this.profileSubject.value as UserProfile; })
+    );
+  }
+
+  register(
+    firstName: string,
+    lastName: string,
+    userName: string,
+    email: string,
+    password: string,
+    confirmPassword: string,
+    phoneNumber?: string,
+    timeZoneId?: string,
+    referralToken?: string,
+  ): Observable<RegisterUserResponseDto> {
+    return this.http.post<RegisterUserResponseDto>(
+      `${this.api}/users/register`,
+      {
+        firstName,
+        lastName,
+        email,
+        userName,
+        password,
+        confirmPassword,
+        phoneNumber,
+        timeZoneId,
+        referralToken,
+      },
+      {
+        context: new HttpContext().set(SKIP_AUTH, true).set(INCLUDE_CREDENTIALS, true),
+      }
     );
   }
 


### PR DESCRIPTION
## Summary
- Switch registration API call to `/users/register`
- Capture first name, last name, username, phone number and time zone in signup form
- Pass all details to backend when registering

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: process hung during bundle generation)*
- `npm run build` *(fails: build process did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68a64067d5388327a64724a9baf9e32a