### PR TITLE
Handle duplicate users during registration

### DIFF
--- a/api/Avancira.API.Tests/UserRegistrationTests.cs
+++ b/api/Avancira.API.Tests/UserRegistrationTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avancira.API.Controllers;
+using Avancira.Application.Audit;
+using Avancira.Application.Caching;
+using Avancira.Application.Identity.Users.Abstractions;
+using Avancira.Application.Identity.Users.Dtos;
+using Avancira.Application.Jobs;
+using Avancira.Application.Storage;
+using Avancira.Domain.Common.Exceptions;
+using Avancira.Infrastructure.Identity.Roles;
+using Avancira.Infrastructure.Identity.Users;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Xunit;
+
+public class UserRegistrationServiceTests
+{
+    private static IUserService CreateService(Mock<UserManager<User>> userManager)
+    {
+        var signInManager = new Mock<SignInManager<User>>(userManager.Object,
+            new Mock<IHttpContextAccessor>().Object,
+            new Mock<IUserClaimsPrincipalFactory<User>>().Object,
+            null, null, null, null);
+        var roleManager = new Mock<RoleManager<Role>>(new Mock<IRoleStore<Role>>().Object, null, null, null, null);
+        var cache = new Mock<ICacheService>().Object;
+        var jobService = new Mock<IJobService>().Object;
+        var notification = new Mock<INotificationService>().Object;
+        var storage = new Mock<IStorageService>().Object;
+        var config = new ConfigurationBuilder().Build();
+        var linkBuilderType = typeof(User).Assembly.GetType("Avancira.Infrastructure.Identity.Users.Services.IdentityLinkBuilder");
+        var linkBuilder = Activator.CreateInstance(linkBuilderType!, config);
+        var serviceType = typeof(User).Assembly.GetType("Avancira.Infrastructure.Identity.Users.Services.UserService");
+        return (IUserService)Activator.CreateInstance(serviceType!, userManager.Object, signInManager.Object, roleManager.Object, null!, cache, jobService, notification, storage, linkBuilder!)!;
+    }
+
+    private static Mock<UserManager<User>> MockUserManager()
+    {
+        var store = new Mock<IUserStore<User>>();
+        return new Mock<UserManager<User>>(store.Object, null, null, null, null, null, null, null, null);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_Throws_WhenEmailExists()
+    {
+        var userManager = MockUserManager();
+        userManager.Setup(x => x.FindByEmailAsync("existing@example.com")).ReturnsAsync(new User { Id = "1", Email = "existing@example.com" });
+
+        var service = CreateService(userManager);
+        var dto = new RegisterUserDto { Email = "existing@example.com", UserName = "newuser", FirstName = "first", LastName = "last", Password = "P@ssw0rd", ConfirmPassword = "P@ssw0rd" };
+
+        Func<Task> act = () => service.RegisterAsync(dto, "http://origin", CancellationToken.None);
+
+        await act.Should().ThrowAsync<AvanciraException>().WithMessage("Email already in use");
+        userManager.Verify(m => m.CreateAsync(It.IsAny<User>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_Throws_WhenUsernameExists()
+    {
+        var userManager = MockUserManager();
+        userManager.Setup(x => x.FindByEmailAsync("new@example.com")).ReturnsAsync((User?)null);
+        userManager.Setup(x => x.FindByNameAsync("existing")).ReturnsAsync(new User { Id = "1", UserName = "existing" });
+
+        var service = CreateService(userManager);
+        var dto = new RegisterUserDto { Email = "new@example.com", UserName = "existing", FirstName = "first", LastName = "last", Password = "P@ssw0rd", ConfirmPassword = "P@ssw0rd" };
+
+        Func<Task> act = () => service.RegisterAsync(dto, "http://origin", CancellationToken.None);
+
+        await act.Should().ThrowAsync<AvanciraException>().WithMessage("Username already in use");
+        userManager.Verify(m => m.CreateAsync(It.IsAny<User>(), It.IsAny<string>()), Times.Never);
+    }
+}
+
+public class UsersControllerRegisterTests
+{
+    [Theory]
+    [InlineData("Email already in use")]
+    [InlineData("Username already in use")]
+    public async Task RegisterUser_ReturnsConflict_OnDuplicate(string message)
+    {
+        var userService = new Mock<IUserService>();
+        userService.Setup(s => s.RegisterAsync(It.IsAny<RegisterUserDto>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                   .ThrowsAsync(new AvanciraException(message));
+
+        var controller = new UsersController(Mock.Of<IAuditService>(), userService.Object, new ConfigurationBuilder().Build());
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Scheme = "http";
+        httpContext.Request.Host = new HostString("localhost");
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        var result = await controller.RegisterUser(new RegisterUserDto(), CancellationToken.None);
+
+        var conflict = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status409Conflict, conflict.StatusCode);
+        Assert.Equal(message, conflict.Value);
+    }
+}

--- a/api/Avancira.API/Controllers/UsersController.cs
+++ b/api/Avancira.API/Controllers/UsersController.cs
@@ -123,8 +123,15 @@ public class UsersController : BaseApiController
     public async Task<IActionResult> RegisterUser([FromBody] RegisterUserDto request, CancellationToken cancellationToken)
     {
         var origin = $"{Request.Scheme}://{Request.Host.Value}{Request.PathBase.Value}";
-        var result = await _userService.RegisterAsync(request, origin, cancellationToken);
-        return Ok(result);
+        try
+        {
+            var result = await _userService.RegisterAsync(request, origin, cancellationToken);
+            return Ok(result);
+        }
+        catch (AvanciraException ex)
+        {
+            return Conflict(ex.Message);
+        }
     }
 
     [HttpPost("self-register")]

--- a/api/Avancira.Infrastructure/Identity/Users/Services/UserService.cs
+++ b/api/Avancira.Infrastructure/Identity/Users/Services/UserService.cs
@@ -111,6 +111,16 @@ internal sealed partial class UserService(
 
     public async Task<RegisterUserResponseDto> RegisterAsync(RegisterUserDto request, string origin, CancellationToken cancellationToken)
     {
+        if (await ExistsWithEmailAsync(request.Email))
+        {
+            throw new AvanciraException("Email already in use");
+        }
+
+        if (await ExistsWithNameAsync(request.UserName))
+        {
+            throw new AvanciraException("Username already in use");
+        }
+
         // create user entity
         var user = new User
         {


### PR DESCRIPTION
## Summary
- prevent user registration when email or username already exists
- return 409 Conflict from user registration endpoint on duplicates
- add unit tests for duplicate email and username registration scenarios

## Testing
- `dotnet test api/Avancira.API.Tests/Avancira.API.Tests.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a645cc2c34832780a8d98663b05c9c