### PR TITLE
Auto-detect signup time zone

### DIFF
--- a/Frontend.Angular/src/app/pages/signup/signup.component.html
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.html
@@ -82,15 +82,8 @@
                 </div>
               </div>
             </div>
-            <div class="form-group">
-              <label class="form-control-label">Time Zone</label>
-              <input
-                id="Input_TimeZoneId"
-                type="text"
-                class="form-control"
-                formControlName="timeZoneId"
-              />
-            </div>
+            <!-- Time zone is detected automatically and stored via form control -->
+            <input type="hidden" formControlName="timeZoneId" />
             <div class="form-group">
               <label class="form-control-label">Email Address</label>
               <input type="email" id="Input_Email" class="form-control" placeholder="Email address"

--- a/Frontend.Angular/src/app/pages/signup/signup.component.ts
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.ts
@@ -64,6 +64,9 @@ export class SignupComponent implements OnInit {
       agreeToTerms: [false, Validators.requiredTrue],
     });
 
+    const timeZoneId = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    this.signupForm.patchValue({ timeZoneId });
+
     this.route.queryParams.subscribe((params) => {
       this.referralToken = params['referral'] || null;
       this.returnUrl = params['returnUrl'] || '/';


### PR DESCRIPTION
## Summary
- Automatically populate signup form with the browser's time zone using `Intl.DateTimeFormat`.
- Hide the time zone field on the signup page to prevent manual edits while still sending it during registration.

## Testing
- `npm test -- --watch=false` *(fails: Error: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_68a649a87b448327be86e4775ab1cd4a