### PR TITLE
refactor: streamline register request handling

### DIFF
--- a/Frontend.Angular/src/app/models/register-user-request.ts
+++ b/Frontend.Angular/src/app/models/register-user-request.ts
@@ -1,0 +1,12 @@
+export interface RegisterUserRequest {
+  firstName: string;
+  lastName: string;
+  userName: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+  phoneNumber?: string;
+  timeZoneId?: string;
+  referralToken?: string;
+  agreeToTerms: boolean;
+}

--- a/Frontend.Angular/src/app/pages/signup/signup.component.ts
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.ts
@@ -18,6 +18,7 @@ import { GoogleAuthService } from '../../services/google-auth.service';
 import { SpinnerService } from '../../services/spinner.service';
 import { ValidatorService } from '../../validators/password-validator.service';
 import { passwordComplexityValidator } from '../../validators/password.validators';
+import { RegisterUserRequest } from '../../models/register-user-request';
 
 @Component({
   selector: 'app-signup',
@@ -93,34 +94,20 @@ export class SignupComponent implements OnInit {
       this.signupForm.markAllAsTouched();
       return;
     }
-    const {
-      firstName,
-      lastName,
-      userName,
-      phoneNumber,
-      timeZoneId,
-      email,
-      password,
-      verifyPassword,
-      agreeToTerms,
-    } = this.signupForm.value;
+    const { verifyPassword, ...rest } = this.signupForm.value;
+    const payload: RegisterUserRequest = {
+      ...rest,
+      confirmPassword: verifyPassword,
+      phoneNumber: rest.phoneNumber || undefined,
+      timeZoneId: rest.timeZoneId || undefined,
+      referralToken: this.referralToken ?? undefined,
+    };
     this.signupError = '';
     this.isSubmitting = true;
     this.spinner.show();
 
     this.authService
-      .register(
-        firstName,
-        lastName,
-        userName,
-        email,
-        password,
-        verifyPassword,
-        phoneNumber || undefined,
-        timeZoneId || undefined,
-        this.referralToken ?? undefined,
-        agreeToTerms,
-      )
+      .register(payload)
       .subscribe({
         next: () => this.loginUser(),
         error: (err) => {

--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -7,6 +7,7 @@ import { jwtDecode } from 'jwt-decode';
 
 import { environment } from '../environments/environment';
 import { INCLUDE_CREDENTIALS, REQUIRES_AUTH, SKIP_AUTH } from '../interceptors/auth.interceptor';
+import { RegisterUserRequest } from '../models/register-user-request';
 import { RegisterUserResponseDto } from '../models/register-user-response';
 import { UserProfile } from '../models/UserProfile';
 
@@ -100,32 +101,10 @@ export class AuthService implements OnDestroy {
     );
   }
 
-  register(
-    firstName: string,
-    lastName: string,
-    userName: string,
-    email: string,
-    password: string,
-    confirmPassword: string,
-    phoneNumber?: string,
-    timeZoneId?: string,
-    referralToken?: string,
-    acceptTerms?: boolean,
-  ): Observable<RegisterUserResponseDto> {
+  register(data: RegisterUserRequest): Observable<RegisterUserResponseDto> {
     return this.http.post<RegisterUserResponseDto>(
       `${this.api}/users/register`,
-      {
-        firstName,
-        lastName,
-        email,
-        userName,
-        password,
-        confirmPassword,
-        phoneNumber,
-        timeZoneId,
-        referralToken,
-        acceptTerms,
-      },
+      data,
       {
         context: new HttpContext().set(SKIP_AUTH, true).set(INCLUDE_CREDENTIALS, true),
       }


### PR DESCRIPTION
## Summary
- add RegisterUserRequest interface with agreeToTerms
- refactor auth service register to take RegisterUserRequest
- pass signup form values directly to new register method

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: Cannot find module exports and missing stylesheets)*

------
https://chatgpt.com/codex/tasks/task_e_68a64af817248327a287e7d8e0c54180