### PR TITLE
Rename agreeToTerms to acceptTerms

### DIFF
--- a/Frontend.Angular/src/app/models/register-user-request.ts
+++ b/Frontend.Angular/src/app/models/register-user-request.ts
@@ -8,5 +8,5 @@ export interface RegisterUserRequest {
   phoneNumber?: string;
   timeZoneId?: string;
   referralToken?: string;
-  agreeToTerms: boolean;
+  acceptTerms: boolean;
 }

--- a/Frontend.Angular/src/app/pages/signup/signup.component.html
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.html
@@ -148,7 +148,7 @@
                   type="checkbox"
                   class="form-check-input"
                   id="agree_checkbox_user"
-                  formControlName="agreeToTerms"
+                  formControlName="acceptTerms"
                 />
                 <label class="form-check-label" for="agree_checkbox_user">
                   I agree to Avancira <a tabindex="-1" href="/privacy-policy">Privacy Policy</a> &amp;
@@ -157,7 +157,7 @@
               </div>
               <div
                 class="text-danger"
-                *ngIf="signupForm.get('agreeToTerms')?.invalid && signupForm.get('agreeToTerms')?.touched"
+                *ngIf="signupForm.get('acceptTerms')?.invalid && signupForm.get('acceptTerms')?.touched"
               >
                 You must agree to the Privacy Policy &amp; Terms.
               </div>

--- a/Frontend.Angular/src/app/pages/signup/signup.component.ts
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.ts
@@ -62,7 +62,7 @@ export class SignupComponent implements OnInit {
         ],
       ],
       verifyPassword: ['', [Validators.required, ValidatorService.matchesPassword('password')]],
-      agreeToTerms: [false, Validators.requiredTrue],
+      acceptTerms: [false, Validators.requiredTrue],
     });
 
     const timeZoneId = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/api/Avancira.Application/Identity/Users/Dtos/RegisterUserDto.cs
+++ b/api/Avancira.Application/Identity/Users/Dtos/RegisterUserDto.cs
@@ -12,6 +12,8 @@ public class RegisterUserDto
     public string? PhoneNumber { get; set; }
     public string? TimeZoneId { get; set; }
     public string? ReferralToken { get; set; }
+
+    [JsonPropertyName("acceptTerms")]
     public bool AcceptTerms { get; set; }
 
     [JsonIgnore]


### PR DESCRIPTION
## Summary
- rename agreeToTerms to acceptTerms in front-end model and sign-up form
- map backend RegisterUserDto property to JSON acceptTerms

## Testing
- `CI=true npm test -- --watch=false --progress=false --browsers=ChromeHeadless` *(fails: process produced no output)*
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a6514617e48327b7b9ae2a5a576d52