### PR TITLE
refactor: rely on validator for AcceptTerms check

### DIFF
--- a/api/Avancira.Infrastructure/Identity/Users/Services/UserService.cs
+++ b/api/Avancira.Infrastructure/Identity/Users/Services/UserService.cs
@@ -121,11 +121,6 @@ internal sealed partial class UserService(
             throw new AvanciraException("Username already in use");
         }
 
-        if (!request.AcceptTerms)
-        {
-            throw new AvanciraException("You must agree to the Privacy Policy & Terms.");
-        }
-
         await using var transaction = await db.Database.BeginTransactionAsync();
 
         try


### PR DESCRIPTION
## Summary
- remove redundant AcceptTerms enforcement in UserService.RegisterAsync

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a657e7ac04832799c962782fc7352c