### PR TITLE
Initialize new users as inactive and activate on email confirmation

### DIFF
--- a/api/Avancira.Infrastructure/Identity/Users/Services/UserService.cs
+++ b/api/Avancira.Infrastructure/Identity/Users/Services/UserService.cs
@@ -56,6 +56,9 @@ internal sealed partial class UserService(
             throw new AvanciraException("Error confirming email.", errors);
         }
 
+        user.IsActive = true;
+        await userManager.UpdateAsync(user);
+
         return $"Account confirmed for {user.Email}.";
     }
 
@@ -135,7 +138,7 @@ internal sealed partial class UserService(
                 UserName = request.UserName,
                 PhoneNumber = request.PhoneNumber,
                 TimeZoneId = request.TimeZoneId,
-                IsActive = true,
+                IsActive = false,
                 EmailConfirmed = false,
                 PhoneNumberConfirmed = false,
             };


### PR DESCRIPTION
## Summary
- Initialize newly registered users with `IsActive = false`
- Activate user after successful email confirmation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a778c924908327a6d77384e3567f4e