### PR TITLE
refactor: centralize password complexity rules

### DIFF
--- a/api/Avancira.API.Tests/ChangePasswordValidatorTests.cs
+++ b/api/Avancira.API.Tests/ChangePasswordValidatorTests.cs
@@ -1,0 +1,39 @@
+using Avancira.Application.Identity.Users.Constants;
+using Avancira.Application.Identity.Users.Dtos;
+using Avancira.Application.Identity.Users.Validators;
+using FluentValidation.TestHelper;
+using Xunit;
+
+public class ChangePasswordValidatorTests
+{
+    private readonly ChangePasswordValidator _validator = new();
+
+    private static ChangePasswordDto CreateDto(string newPassword, string confirmNewPassword) => new()
+    {
+        Password = "Current1!",
+        NewPassword = newPassword,
+        ConfirmNewPassword = confirmNewPassword
+    };
+
+    [Theory]
+    [InlineData("short", UserErrorMessages.PasswordTooShort)]
+    [InlineData("alllowercase1!", UserErrorMessages.PasswordRequiresUppercase)]
+    [InlineData("ALLUPPERCASE1!", UserErrorMessages.PasswordRequiresLowercase)]
+    [InlineData("NoDigits!", UserErrorMessages.PasswordRequiresDigit)]
+    [InlineData("NoSymbols1", UserErrorMessages.PasswordRequiresNonAlphanumeric)]
+    public void Validator_ProvidesSpecificPasswordErrors(string password, string errorMessage)
+    {
+        var dto = CreateDto(password, password);
+        var result = _validator.TestValidate(dto);
+        result.ShouldHaveValidationErrorFor(x => x.NewPassword)
+              .WithErrorMessage(errorMessage);
+    }
+
+    [Fact]
+    public void Validator_AcceptsStrongPassword()
+    {
+        var dto = CreateDto("Str0ng!Pass", "Str0ng!Pass");
+        var result = _validator.TestValidate(dto);
+        result.ShouldNotHaveValidationErrorFor(x => x.NewPassword);
+    }
+}

--- a/api/Avancira.API.Tests/RegisterUserValidatorTests.cs
+++ b/api/Avancira.API.Tests/RegisterUserValidatorTests.cs
@@ -1,0 +1,43 @@
+using Avancira.Application.Identity.Users.Constants;
+using Avancira.Application.Identity.Users.Dtos;
+using Avancira.Application.Identity.Users.Validators;
+using FluentValidation.TestHelper;
+using Xunit;
+
+public class RegisterUserValidatorTests
+{
+    private readonly RegisterUserValidator _validator = new();
+
+    private static RegisterUserDto CreateDto(string password, string confirmPassword) => new()
+    {
+        FirstName = "John",
+        LastName = "Doe",
+        Email = "john@example.com",
+        UserName = "johndoe",
+        Password = password,
+        ConfirmPassword = confirmPassword,
+        AcceptTerms = true
+    };
+
+    [Theory]
+    [InlineData("short", UserErrorMessages.PasswordTooShort)]
+    [InlineData("alllowercase1!", UserErrorMessages.PasswordRequiresUppercase)]
+    [InlineData("ALLUPPERCASE1!", UserErrorMessages.PasswordRequiresLowercase)]
+    [InlineData("NoDigits!", UserErrorMessages.PasswordRequiresDigit)]
+    [InlineData("NoSymbols1", UserErrorMessages.PasswordRequiresNonAlphanumeric)]
+    public void Validator_ProvidesSpecificPasswordErrors(string password, string errorMessage)
+    {
+        var dto = CreateDto(password, password);
+        var result = _validator.TestValidate(dto);
+        result.ShouldHaveValidationErrorFor(x => x.Password)
+              .WithErrorMessage(errorMessage);
+    }
+
+    [Fact]
+    public void Validator_AcceptsStrongPassword()
+    {
+        var dto = CreateDto("Str0ng!Pass", "Str0ng!Pass");
+        var result = _validator.TestValidate(dto);
+        result.ShouldNotHaveValidationErrorFor(x => x.Password);
+    }
+}

--- a/api/Avancira.Application/Identity/Users/Validators/ChangePasswordValidator.cs
+++ b/api/Avancira.Application/Identity/Users/Validators/ChangePasswordValidator.cs
@@ -10,7 +10,7 @@ public class ChangePasswordValidator : AbstractValidator<ChangePasswordDto>
             .NotEmpty();
 
         RuleFor(p => p.NewPassword)
-            .NotEmpty();
+            .ApplyPasswordRules();
 
         RuleFor(p => p.ConfirmNewPassword)
             .Equal(p => p.NewPassword)

--- a/api/Avancira.Application/Identity/Users/Validators/PasswordRuleExtensions.cs
+++ b/api/Avancira.Application/Identity/Users/Validators/PasswordRuleExtensions.cs
@@ -1,0 +1,17 @@
+using Avancira.Application.Identity.Users.Constants;
+using FluentValidation;
+
+namespace Avancira.Application.Identity.Users.Validators;
+
+public static class PasswordRuleExtensions
+{
+    public static IRuleBuilderOptions<T, string> ApplyPasswordRules<T>(this IRuleBuilder<T, string> ruleBuilder)
+        => ruleBuilder
+            .NotEmpty()
+            .MinimumLength(8).WithMessage(UserErrorMessages.PasswordTooShort)
+            .Matches("[A-Z]").WithMessage(UserErrorMessages.PasswordRequiresUppercase)
+            .Matches("[a-z]").WithMessage(UserErrorMessages.PasswordRequiresLowercase)
+            .Matches("[0-9]").WithMessage(UserErrorMessages.PasswordRequiresDigit)
+            .Matches("[^a-zA-Z0-9]").WithMessage(UserErrorMessages.PasswordRequiresNonAlphanumeric);
+}
+

--- a/api/Avancira.Application/Identity/Users/Validators/RegisterUserValidator.cs
+++ b/api/Avancira.Application/Identity/Users/Validators/RegisterUserValidator.cs
@@ -38,10 +38,7 @@ public class RegisterUserValidator : AbstractValidator<RegisterUserDto>
             .WithMessage("Username can only contain letters, numbers, dots, underscores, and hyphens.");
 
         RuleFor(x => x.Password)
-            .NotEmpty()
-            .WithMessage("Password is required.")
-            .MinimumLength(6)
-            .WithMessage("Password must be at least 6 characters long.");
+            .ApplyPasswordRules();
 
         RuleFor(x => x.ConfirmPassword)
             .NotEmpty()

--- a/api/Avancira.Application/Identity/Users/Validators/ResetPasswordValidator.cs
+++ b/api/Avancira.Application/Identity/Users/Validators/ResetPasswordValidator.cs
@@ -11,12 +11,7 @@ public class ResetPasswordValidator : AbstractValidator<ResetPasswordDto>
             .NotEmpty();
 
         RuleFor(x => x.Password)
-            .NotEmpty()
-            .MinimumLength(8).WithMessage(UserErrorMessages.PasswordTooShort)
-            .Matches("[A-Z]").WithMessage(UserErrorMessages.PasswordRequiresUppercase)
-            .Matches("[a-z]").WithMessage(UserErrorMessages.PasswordRequiresLowercase)
-            .Matches("[0-9]").WithMessage(UserErrorMessages.PasswordRequiresDigit)
-            .Matches("[^a-zA-Z0-9]").WithMessage(UserErrorMessages.PasswordRequiresNonAlphanumeric);
+            .ApplyPasswordRules();
 
         RuleFor(x => x.ConfirmPassword)
             .NotEmpty()


### PR DESCRIPTION
## Summary
- reuse password complexity rules via PasswordRuleExtensions
- enforce shared password rules across reset, register and change flows
- add validator tests for RegisterUser and ChangePassword

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a77ada0af4832789affd181d2e1b8e