### PR TITLE
Use password validators on profile password change form

### DIFF
--- a/Frontend.Angular/src/app/pages/profile/profile.component.html
+++ b/Frontend.Angular/src/app/pages/profile/profile.component.html
@@ -192,21 +192,51 @@
 
             <div class="tab-pane" id="bottom-tab3" role="tabpanel">
                 <!-- Change Password Form -->
-                <form (ngSubmit)="changeOldPassword()" #passwordForm="ngForm" novalidate>
+                <form [formGroup]="changePasswordForm" (ngSubmit)="changeOldPassword()" novalidate>
                     <div class="mb-3">
                         <label class="form-label">Current Password</label>
-                        <input type="password" class="form-control" placeholder="Enter current password"
-                            [(ngModel)]="changePasswordData.oldPassword" name="oldPassword" required>
+                        <input type="password" class="form-control" placeholder="Enter current password" formControlName="oldPassword">
+                        <div *ngIf="oldPasswordControl?.touched">
+                            <span *ngIf="oldPasswordControl?.errors?.['required']">
+                                Current password is required.
+                            </span>
+                        </div>
                     </div>
                     <div class="mb-3">
                         <label class="form-label">New Password</label>
-                        <input type="password" class="form-control" placeholder="Enter new password"
-                            [(ngModel)]="changePasswordData.newPassword" name="newPassword" required>
+                        <input type="password" class="form-control" placeholder="Enter new password" formControlName="newPassword">
+                        <div *ngIf="newPasswordControl?.touched">
+                            <span *ngIf="newPasswordControl?.errors?.['required']">
+                                Password is required.
+                            </span>
+                            <span *ngIf="newPasswordControl?.errors?.['minlength']">
+                                Password must be at least 8 characters.
+                            </span>
+                            <span *ngIf="newPasswordControl?.errors?.['noUppercase']">
+                                Password must contain at least one uppercase letter.
+                            </span>
+                            <span *ngIf="newPasswordControl?.errors?.['noLowercase']">
+                                Password must contain at least one lowercase letter.
+                            </span>
+                            <span *ngIf="newPasswordControl?.errors?.['noDigit']">
+                                Password must contain at least one digit.
+                            </span>
+                            <span *ngIf="newPasswordControl?.errors?.['noNonAlphanumeric']">
+                                Password must contain at least one non-alphanumeric character.
+                            </span>
+                        </div>
                     </div>
                     <div class="mb-3">
                         <label class="form-label">Confirm New Password</label>
-                        <input type="password" class="form-control" placeholder="Confirm new password"
-                            [(ngModel)]="changePasswordData.confirmNewPassword" name="confirmNewPassword" required>
+                        <input type="password" class="form-control" placeholder="Confirm new password" formControlName="confirmPassword">
+                        <div *ngIf="confirmPasswordControl?.touched">
+                            <span *ngIf="confirmPasswordControl?.errors?.['required']">
+                                Confirmation is required.
+                            </span>
+                            <span *ngIf="changePasswordForm.errors?.['passwordsMismatch']">
+                                Passwords do not match.
+                            </span>
+                        </div>
                     </div>
                     <div class="text-center">
                         <button type="submit" class="btn btn-primary">Change Password</button>


### PR DESCRIPTION
## Summary
- Apply `passwordComplexityValidator` and `matchPasswords` to the profile change-password form
- Add matching error messages for missing character classes and mismatched confirmation

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: command did not produce results in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a77c427300832789b103ac6aba9602