### PR TITLE
refactor: centralize password rules

### DIFF
--- a/Frontend.Angular/src/app/pages/profile/profile.component.ts
+++ b/Frontend.Angular/src/app/pages/profile/profile.component.ts
@@ -10,6 +10,7 @@ import { AuthService } from '../../services/auth.service';
 import { SpinnerService } from '../../services/spinner.service'; 
 import { UserService } from '../../services/user.service';
 import { matchPasswords, passwordComplexityValidator } from '../../validators/password.validators';
+import { MIN_PASSWORD_LENGTH } from '../../validators/password-rules';
 
 import { ImageFallbackDirective } from '../../directives/image-fallback.directive';
 
@@ -71,7 +72,7 @@ export class ProfileComponent implements OnInit {
           '',
           [
             Validators.required,
-            Validators.minLength(8),
+            Validators.minLength(MIN_PASSWORD_LENGTH),
             passwordComplexityValidator(),
           ],
         ],

--- a/Frontend.Angular/src/app/pages/reset-password/reset-password.component.ts
+++ b/Frontend.Angular/src/app/pages/reset-password/reset-password.component.ts
@@ -8,6 +8,7 @@ import { takeUntil } from 'rxjs/operators';
 import { ResetPasswordRequest } from '../../models/reset-password-request';
 import { UserService } from '../../services/user.service';
 import { matchPasswords, passwordComplexityValidator } from '../../validators/password.validators';
+import { MIN_PASSWORD_LENGTH } from '../../validators/password-rules';
 
 @Component({
   selector: 'app-reset-password',
@@ -37,7 +38,7 @@ export class ResetPasswordComponent implements OnInit, OnDestroy {
           '',
           [
             Validators.required,
-            Validators.minLength(8),
+            Validators.minLength(MIN_PASSWORD_LENGTH),
             passwordComplexityValidator(),
           ],
         ],

--- a/Frontend.Angular/src/app/pages/signup/signup.component.ts
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.ts
@@ -21,6 +21,7 @@ import { GoogleAuthService } from '../../services/google-auth.service';
 import { SpinnerService } from '../../services/spinner.service';
 import { ValidatorService } from '../../validators/password-validator.service';
 import { passwordComplexityValidator } from '../../validators/password.validators';
+import { MIN_PASSWORD_LENGTH } from '../../validators/password-rules';
 import { RegisterUserRequest } from '../../models/register-user-request';
 
 interface SignupForm {
@@ -72,7 +73,7 @@ export class SignupComponent implements OnInit, OnDestroy {
       ]),
       password: this.fb.nonNullable.control('', [
         Validators.required,
-        Validators.minLength(8),
+        Validators.minLength(MIN_PASSWORD_LENGTH),
         passwordComplexityValidator(),
       ]),
       verifyPassword: this.fb.nonNullable.control('', [

--- a/Frontend.Angular/src/app/validators/password-rules.ts
+++ b/Frontend.Angular/src/app/validators/password-rules.ts
@@ -1,0 +1,8 @@
+// Shared password rules used across the Angular app.
+// Keep in sync with api/Avancira.Application/Identity/Users/Constants/PasswordRules.cs
+
+export const MIN_PASSWORD_LENGTH = 8;
+export const UPPERCASE_PATTERN = /[A-Z]/;
+export const LOWERCASE_PATTERN = /[a-z]/;
+export const DIGIT_PATTERN = /[0-9]/;
+export const SYMBOL_PATTERN = /[^a-zA-Z0-9]/;

--- a/Frontend.Angular/src/app/validators/password.validators.ts
+++ b/Frontend.Angular/src/app/validators/password.validators.ts
@@ -1,9 +1,11 @@
 import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 
-export const UPPERCASE_PATTERN = /[A-Z]/;
-export const LOWERCASE_PATTERN = /[a-z]/;
-export const DIGIT_PATTERN = /[0-9]/;
-export const SYMBOL_PATTERN = /[^a-zA-Z0-9]/;
+import {
+  UPPERCASE_PATTERN,
+  LOWERCASE_PATTERN,
+  DIGIT_PATTERN,
+  SYMBOL_PATTERN,
+} from './password-rules';
 
 /**
  * Validates that a control's value meets common password complexity rules.

--- a/api/Avancira.Application/Identity/Users/Constants/PasswordRules.cs
+++ b/api/Avancira.Application/Identity/Users/Constants/PasswordRules.cs
@@ -1,0 +1,15 @@
+namespace Avancira.Application.Identity.Users.Constants;
+
+/// <summary>
+/// Password complexity rules shared with the frontend.
+/// Keep in sync with Frontend.Angular/src/app/validators/password-rules.ts
+/// </summary>
+public static class PasswordRules
+{
+    public const int MinLength = 8;
+    public const string UppercasePattern = "[A-Z]";
+    public const string LowercasePattern = "[a-z]";
+    public const string DigitPattern = "[0-9]";
+    public const string NonAlphanumericPattern = "[^a-zA-Z0-9]";
+}
+

--- a/api/Avancira.Application/Identity/Users/Validators/PasswordRuleExtensions.cs
+++ b/api/Avancira.Application/Identity/Users/Validators/PasswordRuleExtensions.cs
@@ -8,10 +8,10 @@ public static class PasswordRuleExtensions
     public static IRuleBuilderOptions<T, string> ApplyPasswordRules<T>(this IRuleBuilder<T, string> ruleBuilder)
         => ruleBuilder
             .NotEmpty()
-            .MinimumLength(8).WithMessage(UserErrorMessages.PasswordTooShort)
-            .Matches("[A-Z]").WithMessage(UserErrorMessages.PasswordRequiresUppercase)
-            .Matches("[a-z]").WithMessage(UserErrorMessages.PasswordRequiresLowercase)
-            .Matches("[0-9]").WithMessage(UserErrorMessages.PasswordRequiresDigit)
-            .Matches("[^a-zA-Z0-9]").WithMessage(UserErrorMessages.PasswordRequiresNonAlphanumeric);
+            .MinimumLength(PasswordRules.MinLength).WithMessage(UserErrorMessages.PasswordTooShort)
+            .Matches(PasswordRules.UppercasePattern).WithMessage(UserErrorMessages.PasswordRequiresUppercase)
+            .Matches(PasswordRules.LowercasePattern).WithMessage(UserErrorMessages.PasswordRequiresLowercase)
+            .Matches(PasswordRules.DigitPattern).WithMessage(UserErrorMessages.PasswordRequiresDigit)
+            .Matches(PasswordRules.NonAlphanumericPattern).WithMessage(UserErrorMessages.PasswordRequiresNonAlphanumeric);
 }
 


### PR DESCRIPTION
## Summary
- centralize password rule constants for backend and Angular
- reuse password rules across validators and forms

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(terminates early during setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a77d93496c832786fd9ea5fa893a64