### PR TITLE
Add social login support and secure config endpoint

### DIFF
--- a/api/Avancira.API/Avancira.API.csproj
+++ b/api/Avancira.API/Avancira.API.csproj
@@ -23,6 +23,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NSwag.Annotations" Version="14.3.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="9.0.3" />
   </ItemGroup>
 
   

--- a/api/Avancira.API/Controllers/ConfigsController.cs
+++ b/api/Avancira.API/Controllers/ConfigsController.cs
@@ -11,19 +11,16 @@ public class ConfigsController : BaseApiController
     private readonly StripeOptions _stripeOptions;
     private readonly PayPalOptions _payPalOptions;
     private readonly GoogleOptions _googleOptions;
-    private readonly FacebookOptions _facebookOptions;
 
     public ConfigsController(
         IOptions<StripeOptions> stripeOptions,
         IOptions<PayPalOptions> payPalOptions,
-        IOptions<GoogleOptions> googleOptions,
-        IOptions<FacebookOptions> facebookOptions
+        IOptions<GoogleOptions> googleOptions
     )
     {
         _stripeOptions = stripeOptions.Value;
         _payPalOptions = payPalOptions.Value;
         _googleOptions = googleOptions.Value;
-        _facebookOptions = facebookOptions.Value;
     }
 
     // Read
@@ -35,9 +32,7 @@ public class ConfigsController : BaseApiController
             stripePublishableKey = _stripeOptions.PublishableKey,
             payPalClientId = _payPalOptions.ClientId,
             googleMapsApiKey = _googleOptions.ApiKey,
-            googleClientId = _googleOptions.ClientId,
-            googleClientSecret = _googleOptions.ClientSecret,
-            facebookAppId = _facebookOptions.AppId
+            googleClientId = _googleOptions.ClientId
         };
 
         return Ok(config);

--- a/api/Avancira.API/Controllers/ExternalAuthController.cs
+++ b/api/Avancira.API/Controllers/ExternalAuthController.cs
@@ -1,0 +1,93 @@
+using System.Security.Claims;
+using Avancira.Application.Auth;
+using Avancira.Application.Common;
+using Avancira.Application.Identity.Tokens;
+using Avancira.Application.Identity.Tokens.Dtos;
+using Avancira.Infrastructure.Identity.Users;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Avancira.API.Controllers;
+
+[Route("api/auth")]
+public class ExternalAuthController : BaseApiController
+{
+    private readonly IExternalAuthService _externalAuthService;
+    private readonly UserManager<User> _userManager;
+    private readonly ITokenService _tokenService;
+    private readonly IClientInfoService _clientInfoService;
+
+    public ExternalAuthController(
+        IExternalAuthService externalAuthService,
+        UserManager<User> userManager,
+        ITokenService tokenService,
+        IClientInfoService clientInfoService)
+    {
+        _externalAuthService = externalAuthService;
+        _userManager = userManager;
+        _tokenService = tokenService;
+        _clientInfoService = clientInfoService;
+    }
+
+    [HttpPost("external-login")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(TokenResponse), StatusCodes.Status200OK)]
+    public async Task<IActionResult> ExternalLogin([FromBody] ExternalLoginRequest request, CancellationToken cancellationToken)
+    {
+        var info = request.Provider.ToLowerInvariant() switch
+        {
+            "google" => await _externalAuthService.ValidateGoogleTokenAsync(request.Token),
+            "facebook" => await _externalAuthService.ValidateFacebookTokenAsync(request.Token),
+            _ => null
+        };
+
+        if (info is null) return Unauthorized();
+
+        var user = await _userManager.FindByLoginAsync(info.LoginProvider, info.ProviderKey);
+        if (user is null)
+        {
+            var email = info.Principal.FindFirstValue(ClaimTypes.Email);
+            if (string.IsNullOrEmpty(email)) return Unauthorized();
+
+            user = await _userManager.FindByEmailAsync(email);
+            if (user is null)
+            {
+                user = new User
+                {
+                    UserName = email,
+                    Email = email,
+                    EmailConfirmed = true,
+                    FirstName = info.Principal.FindFirstValue(ClaimTypes.Name) ?? string.Empty
+                };
+                await _userManager.CreateAsync(user);
+            }
+
+            await _userManager.AddLoginAsync(user, info);
+        }
+
+        var clientInfo = await _clientInfoService.GetClientInfoAsync();
+        var tokens = await _tokenService.GenerateTokenForUserAsync(user.Id, clientInfo, cancellationToken);
+
+        SetRefreshTokenCookie(tokens.RefreshToken, tokens.RefreshTokenExpiryTime);
+
+        return Ok(new TokenResponse(tokens.Token));
+    }
+
+    private void SetRefreshTokenCookie(string refreshToken, DateTime expires)
+    {
+        var cookieOptions = new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = true,
+            SameSite = SameSiteMode.None,
+            Path = "/api/auth"
+        };
+
+        cookieOptions.Expires = expires;
+
+        Response.Cookies.Append("refreshToken", refreshToken, cookieOptions);
+    }
+
+    public record ExternalLoginRequest(string Provider, string Token);
+}

--- a/api/Avancira.API/Program.cs
+++ b/api/Avancira.API/Program.cs
@@ -5,6 +5,7 @@ using Avancira.ServiceDefaults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Authentication;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -63,6 +64,18 @@ builder.Services.AddRateLimiter(options =>
                 QueueLimit = 0
             }));
 });
+
+builder.Services.AddAuthentication()
+    .AddGoogle(o =>
+    {
+        o.ClientId = builder.Configuration["Avancira:ExternalServices:Google:ClientId"]!;
+        o.ClientSecret = builder.Configuration["Avancira:ExternalServices:Google:ClientSecret"]!;
+    })
+    .AddFacebook(o =>
+    {
+        o.AppId = builder.Configuration["Avancira:ExternalServices:Facebook:AppId"]!;
+        o.AppSecret = builder.Configuration["Avancira:ExternalServices:Facebook:AppSecret"]!;
+    });
 
 var app = builder.Build();
 

--- a/api/Avancira.Application/Auth/IExternalAuthService.cs
+++ b/api/Avancira.Application/Auth/IExternalAuthService.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace Avancira.Application.Auth;
+
+public interface IExternalAuthService
+{
+    Task<ExternalLoginInfo?> ValidateGoogleTokenAsync(string idToken);
+    Task<ExternalLoginInfo?> ValidateFacebookTokenAsync(string accessToken);
+}

--- a/api/Avancira.Application/Avancira.Application.csproj
+++ b/api/Avancira.Application/Avancira.Application.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageReference Include="Mapster" Version="7.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/api/Avancira.Application/Identity/Tokens/ITokenService.cs
+++ b/api/Avancira.Application/Identity/Tokens/ITokenService.cs
@@ -8,6 +8,7 @@ namespace Avancira.Application.Identity.Tokens;
 public interface ITokenService
 {
     Task<TokenPair> GenerateTokenAsync(TokenGenerationDto request, ClientInfo clientInfo, CancellationToken cancellationToken);
+    Task<TokenPair> GenerateTokenForUserAsync(string userId, ClientInfo clientInfo, CancellationToken cancellationToken);
     Task<TokenPair> RefreshTokenAsync(string? token, string refreshToken, ClientInfo clientInfo, CancellationToken cancellationToken);
     Task RevokeTokenAsync(string refreshToken, string userId, ClientInfo clientInfo, CancellationToken cancellationToken);
     Task<IReadOnlyList<SessionDto>> GetSessionsAsync(string userId, CancellationToken ct);

--- a/api/Avancira.Infrastructure/Auth/ExternalAuthService.cs
+++ b/api/Avancira.Infrastructure/Auth/ExternalAuthService.cs
@@ -1,0 +1,63 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Avancira.Application.Auth;
+using Avancira.Application.Options;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
+namespace Avancira.Infrastructure.Auth;
+
+public class ExternalAuthService : IExternalAuthService
+{
+    private readonly HttpClient _httpClient;
+    private readonly GoogleOptions _googleOptions;
+
+    public ExternalAuthService(IHttpClientFactory httpClientFactory, IOptions<GoogleOptions> googleOptions)
+    {
+        _httpClient = httpClientFactory.CreateClient();
+        _googleOptions = googleOptions.Value;
+    }
+
+    public async Task<ExternalLoginInfo?> ValidateGoogleTokenAsync(string idToken)
+    {
+        var response = await _httpClient.GetAsync($"https://oauth2.googleapis.com/tokeninfo?id_token={idToken}");
+        if (!response.IsSuccessStatusCode) return null;
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = doc.RootElement;
+        if (root.GetProperty("aud").GetString() != _googleOptions.ClientId) return null;
+
+        var email = root.GetProperty("email").GetString() ?? string.Empty;
+        var sub = root.GetProperty("sub").GetString() ?? string.Empty;
+        var name = root.TryGetProperty("name", out var nameEl) ? nameEl.GetString() : string.Empty;
+
+        var claims = new List<Claim>
+        {
+            new Claim(ClaimTypes.Email, email),
+            new Claim(ClaimTypes.Name, name ?? string.Empty)
+        };
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "google"));
+        return new ExternalLoginInfo(principal, "Google", sub, "Google");
+    }
+
+    public async Task<ExternalLoginInfo?> ValidateFacebookTokenAsync(string accessToken)
+    {
+        var response = await _httpClient.GetAsync($"https://graph.facebook.com/me?fields=id,name,email&access_token={accessToken}");
+        if (!response.IsSuccessStatusCode) return null;
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = doc.RootElement;
+        var id = root.GetProperty("id").GetString();
+        if (string.IsNullOrEmpty(id)) return null;
+        var email = root.TryGetProperty("email", out var emailEl) ? emailEl.GetString() : string.Empty;
+        var name = root.TryGetProperty("name", out var nameEl) ? nameEl.GetString() : string.Empty;
+
+        var claims = new List<Claim>
+        {
+            new Claim(ClaimTypes.Email, email ?? string.Empty),
+            new Claim(ClaimTypes.Name, name ?? string.Empty)
+        };
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "facebook"));
+        return new ExternalLoginInfo(principal, "Facebook", id!, "Facebook");
+    }
+}

--- a/api/Avancira.Infrastructure/Auth/JwtTokenService.cs
+++ b/api/Avancira.Infrastructure/Auth/JwtTokenService.cs
@@ -9,7 +9,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
 
-namespace Avancira.Infrastructure.Catalog
+namespace Avancira.Infrastructure.Auth
 {
     public class JwtTokenService : IJwtTokenService
     {

--- a/api/Avancira.Infrastructure/Common/Extensions.cs
+++ b/api/Avancira.Infrastructure/Common/Extensions.cs
@@ -10,6 +10,7 @@ using Avancira.Application.Messaging;
 using Avancira.Application.Payments;
 using Avancira.Application.Subscriptions;
 using Avancira.Application.Common;
+using Avancira.Application.Auth;
 using Avancira.Infrastructure.Auth;
 using Avancira.Infrastructure.Billing;
 using Avancira.Infrastructure.Identity.Audit;
@@ -51,6 +52,7 @@ namespace Avancira.Infrastructure.Catalog
             services.AddTransient<IWalletService, WalletService>();
             services.AddTransient<ILessonService, LessonService>();
             services.AddTransient<IJwtTokenService, JwtTokenService>();
+            services.AddHttpClient<IExternalAuthService, ExternalAuthService>();
             services.AddTransient<IGeolocationService, GeolocationService>();
             services.AddTransient<IClientInfoService, ClientInfoService>();
             services.AddTransient<IFileUploadService, FileUploadService>();

--- a/api/Avancira.Infrastructure/Identity/Tokens/TokenService.cs
+++ b/api/Avancira.Infrastructure/Identity/Tokens/TokenService.cs
@@ -55,6 +55,27 @@ public sealed class TokenService : ITokenService
         return await GenerateTokens(user, clientInfo, cancellationToken);
     }
 
+    public async Task<TokenPair> GenerateTokenForUserAsync(string userId, ClientInfo clientInfo, CancellationToken cancellationToken)
+    {
+        var user = await _userManager.FindByIdAsync(userId);
+        if (user is null)
+        {
+            throw new UnauthorizedException();
+        }
+
+        if (!user.IsActive)
+        {
+            throw new UnauthorizedException("user is deactivated");
+        }
+
+        if (!user.EmailConfirmed)
+        {
+            throw new UnauthorizedException("email not confirmed");
+        }
+
+        return await GenerateTokens(user, clientInfo, cancellationToken);
+    }
+
     public async Task<TokenPair> RefreshTokenAsync(string? token, string refreshToken, ClientInfo clientInfo, CancellationToken cancellationToken)
     {
         var hashedRefreshToken = HashToken(refreshToken);


### PR DESCRIPTION
## Summary
- expose only public keys in `ConfigsController`
- add Google and Facebook authentication configuration
- implement external auth service and controller for social login
- extend token service for existing users and wire Angular client

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: module resolution and build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a77f2b26d08327940ad84f2ab54b95