### PR TITLE
Implement external social login handlers with tests

### DIFF
--- a/Frontend.Angular/src/app/pages/signin/signin.component.spec.ts
+++ b/Frontend.Angular/src/app/pages/signin/signin.component.spec.ts
@@ -1,16 +1,46 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
 
 import { SigninComponent } from './signin.component';
+import { AuthService } from '../../services/auth.service';
+import { SpinnerService } from '../../services/spinner.service';
+import { ToastrService } from 'ngx-toastr';
+import { ConfigService } from '../../services/config.service';
+import { AlertService } from '../../services/alert.service';
+import { UserService } from '../../services/user.service';
+import { GoogleAuthService } from '../../services/google-auth.service';
+import { FacebookService } from 'ngx-facebook';
 
 describe('LoginComponent', () => {
   let component: SigninComponent;
   let fixture: ComponentFixture<SigninComponent>;
+  let authService: jasmine.SpyObj<AuthService>;
+  let router: jasmine.SpyObj<Router>;
+  let spinner: jasmine.SpyObj<SpinnerService>;
+  let toastr: jasmine.SpyObj<ToastrService>;
 
   beforeEach(async () => {
+    authService = jasmine.createSpyObj('AuthService', ['externalLogin']);
+    router = jasmine.createSpyObj('Router', ['navigateByUrl']);
+    spinner = jasmine.createSpyObj('SpinnerService', ['show', 'hide']);
+    toastr = jasmine.createSpyObj('ToastrService', ['error']);
+
     await TestBed.configureTestingModule({
-      imports: [SigninComponent]
-    })
-    .compileComponents();
+      imports: [SigninComponent],
+      providers: [
+        { provide: AuthService, useValue: authService },
+        { provide: Router, useValue: router },
+        { provide: SpinnerService, useValue: spinner },
+        { provide: ToastrService, useValue: toastr },
+        { provide: ActivatedRoute, useValue: { queryParams: of({}) } },
+        { provide: ConfigService, useValue: { loadConfig: () => of({}), get: () => '' } },
+        { provide: AlertService, useValue: {} },
+        { provide: UserService, useValue: {} },
+        { provide: GoogleAuthService, useValue: {} },
+        { provide: FacebookService, useValue: { init: () => {} } },
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(SigninComponent);
     component = fixture.componentInstance;
@@ -19,5 +49,25 @@ describe('LoginComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should navigate to returnUrl on successful social login', () => {
+    authService.externalLogin.and.returnValue(of({} as any));
+    component.returnUrl = '/home';
+
+    component.handleSocialLogin('google', 'token123');
+
+    expect(authService.externalLogin).toHaveBeenCalledWith('google', 'token123');
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/home');
+    expect(spinner.hide).toHaveBeenCalled();
+  });
+
+  it('should show error toast and hide spinner on social login error', () => {
+    authService.externalLogin.and.returnValue(throwError(() => new Error('fail')));
+
+    component.handleSocialLogin('google', 'token123');
+
+    expect(toastr.error).toHaveBeenCalled();
+    expect(spinner.hide).toHaveBeenCalled();
   });
 });

--- a/Frontend.Angular/src/app/pages/signin/signin.component.ts
+++ b/Frontend.Angular/src/app/pages/signin/signin.component.ts
@@ -120,16 +120,19 @@ export class SigninComponent implements OnInit {
   }
 
   /** Common handler for social login */
-  handleSocialLogin(provider: string, token: string): void {
-    // this.authService.socialLogin(provider, token).subscribe({
-    //   next: () => {
-    //     this.router.navigateByUrl(this.returnUrl);
-    //   },
-    //   error: (err : any) => {
-    //     console.error(`${provider} login error:`, err);
-    //     this.toastr.error(`${provider} login failed.`, 'Error');
-    //   },
-    // });
+  handleSocialLogin(provider: 'google' | 'facebook', token: string): void {
+    this.authService
+      .externalLogin(provider, token)
+      .pipe(finalize(() => this.spinner.hide()))
+      .subscribe({
+        next: () => {
+          this.router.navigateByUrl(this.returnUrl);
+        },
+        error: (err: any) => {
+          console.error(`${provider} login error:`, err);
+          this.toastr.error(`${provider} login failed.`, 'Error');
+        },
+      });
   }
 
   /** Password reset prompt */

--- a/Frontend.Angular/src/app/pages/signup/signup.component.spec.ts
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.spec.ts
@@ -1,16 +1,42 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
 
 import { SignupComponent } from './signup.component';
+import { AuthService } from '../../services/auth.service';
+import { SpinnerService } from '../../services/spinner.service';
+import { ToastrService } from 'ngx-toastr';
+import { ConfigService } from '../../services/config.service';
+import { GoogleAuthService } from '../../services/google-auth.service';
+import { FacebookService } from 'ngx-facebook';
 
 describe('SignupComponent', () => {
   let component: SignupComponent;
   let fixture: ComponentFixture<SignupComponent>;
+  let authService: jasmine.SpyObj<AuthService>;
+  let router: jasmine.SpyObj<Router>;
+  let spinner: jasmine.SpyObj<SpinnerService>;
+  let toastr: jasmine.SpyObj<ToastrService>;
 
   beforeEach(async () => {
+    authService = jasmine.createSpyObj('AuthService', ['externalLogin']);
+    router = jasmine.createSpyObj('Router', ['navigateByUrl']);
+    spinner = jasmine.createSpyObj('SpinnerService', ['show', 'hide']);
+    toastr = jasmine.createSpyObj('ToastrService', ['error']);
+
     await TestBed.configureTestingModule({
-      imports: [SignupComponent]
-    })
-    .compileComponents();
+      imports: [SignupComponent],
+      providers: [
+        { provide: AuthService, useValue: authService },
+        { provide: Router, useValue: router },
+        { provide: SpinnerService, useValue: spinner },
+        { provide: ToastrService, useValue: toastr },
+        { provide: ActivatedRoute, useValue: { queryParams: of({}) } },
+        { provide: ConfigService, useValue: { loadConfig: () => of({}), get: () => '' } },
+        { provide: GoogleAuthService, useValue: {} },
+        { provide: FacebookService, useValue: { init: () => {} } },
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(SignupComponent);
     component = fixture.componentInstance;
@@ -19,5 +45,25 @@ describe('SignupComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should navigate to returnUrl on successful social signup', () => {
+    authService.externalLogin.and.returnValue(of({} as any));
+    component.returnUrl = '/home';
+
+    component.handleSocialSignup('google', 'token123');
+
+    expect(authService.externalLogin).toHaveBeenCalledWith('google', 'token123');
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/home');
+    expect(spinner.hide).toHaveBeenCalled();
+  });
+
+  it('should show error toast and hide spinner on social signup error', () => {
+    authService.externalLogin.and.returnValue(throwError(() => new Error('fail')));
+
+    component.handleSocialSignup('google', 'token123');
+
+    expect(toastr.error).toHaveBeenCalled();
+    expect(spinner.hide).toHaveBeenCalled();
   });
 });

--- a/Frontend.Angular/src/app/pages/signup/signup.component.ts
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.ts
@@ -188,20 +188,19 @@ export class SignupComponent implements OnInit, OnDestroy {
   }
 
   /** Handle token verification with backend */
-  handleSocialSignup(provider: string, token: string): void {
-    // this.authService.socialLogin(provider, token).subscribe({
-    //   next: (res) => {
-    //     if (res) {
-    //       this.router.navigateByUrl(this.returnUrl);
-    //     } else {
-    //       this.router.navigate(['/complete-registration']);
-    //     }
-    //   },
-    //   error: (err) => {
-    //     console.error(`${provider} signup error:`, err);
-    //     this.signupError = `${provider} signup failed.`;
-    //   },
-    // });
+  handleSocialSignup(provider: 'google' | 'facebook', token: string): void {
+    this.authService
+      .externalLogin(provider, token)
+      .pipe(finalize(() => this.spinner.hide()))
+      .subscribe({
+        next: () => {
+          this.router.navigateByUrl(this.returnUrl);
+        },
+        error: (err) => {
+          console.error(`${provider} signup error:`, err);
+          this.toastr.error(`${provider} signup failed.`, 'Error');
+        },
+      });
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## Summary
- Implement social login/signup handlers using AuthService.externalLogin
- Redirect to returnUrl on success and surface errors with toasts
- Add unit tests for social auth navigation and error paths

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false --include src/app/pages/signin/signin.component.spec.ts,src/app/pages/signup/signup.component.spec.ts` *(fails: Module '"../../models/user"' has no exported member 'DiplomaStatus')*


------
https://chatgpt.com/codex/tasks/task_e_68a78a77e3d88327931204e57753276b