### PR TITLE
Consolidate external auth token validation

### DIFF
--- a/api/Avancira.API.Tests/ExternalAuthServiceTests.cs
+++ b/api/Avancira.API.Tests/ExternalAuthServiceTests.cs
@@ -50,12 +50,12 @@ public class ExternalAuthServiceTests
     }
 
     [Fact]
-    public async Task ValidateGoogleTokenAsync_ReturnsInfo_OnValidToken()
+    public async Task ValidateTokenAsync_ReturnsInfo_OnValidGoogleToken()
     {
         var service = CreateService(new StubMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)));
         var token = CreateGoogleToken("valid-client-id");
 
-        var result = await service.ValidateGoogleTokenAsync(token);
+        var result = await service.ValidateTokenAsync("google", token);
 
         result.Succeeded.Should().BeTrue();
         result.LoginInfo.Should().NotBeNull();
@@ -63,19 +63,19 @@ public class ExternalAuthServiceTests
     }
 
     [Fact]
-    public async Task ValidateGoogleTokenAsync_Fails_OnInvalidAudience()
+    public async Task ValidateTokenAsync_Fails_OnInvalidGoogleAudience()
     {
         var service = CreateService(new StubMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)));
         var token = CreateGoogleToken("wrong-client-id");
 
-        var result = await service.ValidateGoogleTokenAsync(token);
+        var result = await service.ValidateTokenAsync("google", token);
 
         result.Succeeded.Should().BeFalse();
         result.Error.Should().NotBeNull();
     }
 
     [Fact]
-    public async Task ValidateFacebookTokenAsync_ReturnsInfo_OnValidToken()
+    public async Task ValidateTokenAsync_ReturnsInfo_OnValidFacebookToken()
     {
         var handler = new StubMessageHandler(req =>
         {
@@ -96,7 +96,7 @@ public class ExternalAuthServiceTests
         });
         var service = CreateService(handler);
 
-        var result = await service.ValidateFacebookTokenAsync("token");
+        var result = await service.ValidateTokenAsync("facebook", "token");
 
         result.Succeeded.Should().BeTrue();
         result.LoginInfo.Should().NotBeNull();
@@ -104,7 +104,7 @@ public class ExternalAuthServiceTests
     }
 
     [Fact]
-    public async Task ValidateFacebookTokenAsync_Fails_WhenInvalid()
+    public async Task ValidateTokenAsync_Fails_OnInvalidFacebookToken()
     {
         var handler = new StubMessageHandler(req =>
         {
@@ -120,7 +120,7 @@ public class ExternalAuthServiceTests
         });
         var service = CreateService(handler);
 
-        var result = await service.ValidateFacebookTokenAsync("token");
+        var result = await service.ValidateTokenAsync("facebook", "token");
 
         result.Succeeded.Should().BeFalse();
         result.Error.Should().NotBeNull();

--- a/api/Avancira.API/Controllers/ExternalAuthController.cs
+++ b/api/Avancira.API/Controllers/ExternalAuthController.cs
@@ -35,12 +35,7 @@ public class ExternalAuthController : BaseApiController
     [ProducesResponseType(typeof(TokenResponse), StatusCodes.Status200OK)]
     public async Task<IActionResult> ExternalLogin([FromBody] ExternalLoginRequest request, CancellationToken cancellationToken)
     {
-        var result = request.Provider.ToLowerInvariant() switch
-        {
-            "google" => await _externalAuthService.ValidateGoogleTokenAsync(request.Token),
-            "facebook" => await _externalAuthService.ValidateFacebookTokenAsync(request.Token),
-            _ => ExternalAuthResult.Fail("Unsupported provider")
-        };
+        var result = await _externalAuthService.ValidateTokenAsync(request.Provider, request.Token);
 
         if (!result.Succeeded || result.LoginInfo is null)
             return Unauthorized(result.Error);

--- a/api/Avancira.Application/Auth/IExternalAuthService.cs
+++ b/api/Avancira.Application/Auth/IExternalAuthService.cs
@@ -4,6 +4,5 @@ namespace Avancira.Application.Auth;
 
 public interface IExternalAuthService
 {
-    Task<ExternalAuthResult> ValidateGoogleTokenAsync(string idToken);
-    Task<ExternalAuthResult> ValidateFacebookTokenAsync(string accessToken);
+    Task<ExternalAuthResult> ValidateTokenAsync(string provider, string token);
 }

--- a/api/Avancira.Infrastructure/Auth/ExternalAuthService.cs
+++ b/api/Avancira.Infrastructure/Auth/ExternalAuthService.cs
@@ -29,7 +29,17 @@ public class ExternalAuthService : IExternalAuthService
         _logger = logger;
     }
 
-    public Task<ExternalAuthResult> ValidateGoogleTokenAsync(string idToken)
+    public Task<ExternalAuthResult> ValidateTokenAsync(string provider, string token)
+    {
+        return provider.ToLowerInvariant() switch
+        {
+            "google" => ValidateGoogleTokenAsync(token),
+            "facebook" => ValidateFacebookTokenAsync(token),
+            _ => Task.FromResult(ExternalAuthResult.Fail("Unsupported provider"))
+        };
+    }
+
+    private Task<ExternalAuthResult> ValidateGoogleTokenAsync(string idToken)
     {
         var handler = new JwtSecurityTokenHandler();
         var parameters = new TokenValidationParameters
@@ -71,7 +81,7 @@ public class ExternalAuthService : IExternalAuthService
         }
     }
 
-    public async Task<ExternalAuthResult> ValidateFacebookTokenAsync(string accessToken)
+    private async Task<ExternalAuthResult> ValidateFacebookTokenAsync(string accessToken)
     {
         try
         {


### PR DESCRIPTION
## Summary
- add unified ValidateTokenAsync to external auth service
- update controller and tests to use provider-based token validation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7909a5918832788376ea8347bc475