### PR TITLE
Refactor external auth to use provider-specific validators

### DIFF
--- a/api/Avancira.API.Tests/ExternalAuthServiceTests.cs
+++ b/api/Avancira.API.Tests/ExternalAuthServiceTests.cs
@@ -26,8 +26,15 @@ public class ExternalAuthServiceTests
         factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
         var gOptions = Options.Create(googleOptions ?? new GoogleOptions { ClientId = "valid-client-id" });
         var fOptions = Options.Create(facebookOptions ?? new FacebookOptions { AppId = "app", AppSecret = "secret" });
-        var logger = Mock.Of<ILogger<ExternalAuthService>>();
-        return new ExternalAuthService(factory.Object, gOptions, fOptions, logger);
+        var serviceLogger = Mock.Of<ILogger<ExternalAuthService>>();
+        var googleLogger = Mock.Of<ILogger<GoogleTokenValidator>>();
+        var facebookLogger = Mock.Of<ILogger<FacebookTokenValidator>>();
+        var validators = new IExternalTokenValidator[]
+        {
+            new GoogleTokenValidator(gOptions, googleLogger),
+            new FacebookTokenValidator(factory.Object, fOptions, facebookLogger)
+        };
+        return new ExternalAuthService(validators, serviceLogger);
     }
 
     private static string CreateGoogleToken(string audience)

--- a/api/Avancira.Infrastructure/Auth/ExternalAuthService.cs
+++ b/api/Avancira.Infrastructure/Auth/ExternalAuthService.cs
@@ -1,135 +1,29 @@
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
-using System.Text.Json;
 using Avancira.Application.Auth;
-using Avancira.Application.Options;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
 
 namespace Avancira.Infrastructure.Auth;
 
 public class ExternalAuthService : IExternalAuthService
 {
-    private readonly HttpClient _httpClient;
-    private readonly GoogleOptions _googleOptions;
-    private readonly FacebookOptions _facebookOptions;
+    private readonly Dictionary<string, IExternalTokenValidator> _validators;
     private readonly ILogger<ExternalAuthService> _logger;
 
     public ExternalAuthService(
-        IHttpClientFactory httpClientFactory,
-        IOptions<GoogleOptions> googleOptions,
-        IOptions<FacebookOptions> facebookOptions,
+        IEnumerable<IExternalTokenValidator> validators,
         ILogger<ExternalAuthService> logger)
     {
-        _httpClient = httpClientFactory.CreateClient();
-        _googleOptions = googleOptions.Value;
-        _facebookOptions = facebookOptions.Value;
+        _validators = validators.ToDictionary(v => v.Provider, StringComparer.OrdinalIgnoreCase);
         _logger = logger;
     }
 
     public Task<ExternalAuthResult> ValidateTokenAsync(string provider, string token)
     {
-        return provider.ToLowerInvariant() switch
+        if (_validators.TryGetValue(provider, out var validator))
         {
-            "google" => ValidateGoogleTokenAsync(token),
-            "facebook" => ValidateFacebookTokenAsync(token),
-            _ => Task.FromResult(ExternalAuthResult.Fail("Unsupported provider"))
-        };
-    }
-
-    private Task<ExternalAuthResult> ValidateGoogleTokenAsync(string idToken)
-    {
-        var handler = new JwtSecurityTokenHandler();
-        var parameters = new TokenValidationParameters
-        {
-            ValidateIssuer = true,
-            ValidIssuers = new[] { "accounts.google.com", "https://accounts.google.com" },
-            ValidateAudience = true,
-            ValidAudience = _googleOptions.ClientId,
-            ValidateLifetime = true,
-            ClockSkew = TimeSpan.FromMinutes(5),
-            ValidateIssuerSigningKey = false
-        };
-
-        try
-        {
-            var principal = handler.ValidateToken(idToken, parameters, out _);
-            var sub = principal.FindFirstValue("sub") ?? string.Empty;
-            var email = principal.FindFirstValue(ClaimTypes.Email) ?? string.Empty;
-            var name = principal.FindFirstValue(ClaimTypes.Name) ?? string.Empty;
-
-            var claims = new List<Claim>
-            {
-                new Claim(ClaimTypes.Email, email),
-                new Claim(ClaimTypes.Name, name)
-            };
-            var identity = new ClaimsIdentity(claims, "google");
-            var info = new ExternalLoginInfo(new ClaimsPrincipal(identity), "Google", sub, "Google");
-            return Task.FromResult(ExternalAuthResult.Success(info));
+            return validator.ValidateAsync(token);
         }
-        catch (SecurityTokenException ex)
-        {
-            _logger.LogWarning(ex, "Google token validation failed");
-            return Task.FromResult(ExternalAuthResult.Fail("Invalid Google token"));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error validating Google token");
-            return Task.FromResult(ExternalAuthResult.Fail("Error validating Google token"));
-        }
-    }
 
-    private async Task<ExternalAuthResult> ValidateFacebookTokenAsync(string accessToken)
-    {
-        try
-        {
-            var appToken = $"{_facebookOptions.AppId}|{_facebookOptions.AppSecret}";
-            var debugResponse = await _httpClient.GetAsync($"https://graph.facebook.com/debug_token?input_token={accessToken}&access_token={appToken}");
-            if (!debugResponse.IsSuccessStatusCode)
-            {
-                _logger.LogWarning("Facebook debug_token request failed: {StatusCode}", debugResponse.StatusCode);
-                return ExternalAuthResult.Fail("Invalid Facebook token");
-            }
-
-            using var debugDoc = JsonDocument.Parse(await debugResponse.Content.ReadAsStringAsync());
-            var data = debugDoc.RootElement.GetProperty("data");
-            var appId = data.GetProperty("app_id").GetString();
-            var isValid = data.GetProperty("is_valid").GetBoolean();
-            var expiresAt = data.GetProperty("expires_at").GetInt64();
-            if (appId != _facebookOptions.AppId || !isValid || DateTimeOffset.FromUnixTimeSeconds(expiresAt) <= DateTimeOffset.UtcNow)
-            {
-                _logger.LogWarning("Facebook token invalid: app_id={AppId} is_valid={IsValid} exp={Exp}", appId, isValid, expiresAt);
-                return ExternalAuthResult.Fail("Invalid Facebook token");
-            }
-
-            var profileResponse = await _httpClient.GetAsync($"https://graph.facebook.com/me?fields=id,name,email&access_token={accessToken}");
-            if (!profileResponse.IsSuccessStatusCode)
-            {
-                _logger.LogWarning("Facebook profile request failed: {StatusCode}", profileResponse.StatusCode);
-                return ExternalAuthResult.Fail("Unable to retrieve Facebook user info");
-            }
-
-            using var profileDoc = JsonDocument.Parse(await profileResponse.Content.ReadAsStringAsync());
-            var root = profileDoc.RootElement;
-            var id = root.GetProperty("id").GetString() ?? string.Empty;
-            var email = root.TryGetProperty("email", out var emailEl) ? emailEl.GetString() ?? string.Empty : string.Empty;
-            var name = root.TryGetProperty("name", out var nameEl) ? nameEl.GetString() ?? string.Empty : string.Empty;
-
-            var claims = new List<Claim>
-            {
-                new Claim(ClaimTypes.Email, email),
-                new Claim(ClaimTypes.Name, name)
-            };
-            var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "facebook"));
-            var info = new ExternalLoginInfo(principal, "Facebook", id, "Facebook");
-            return ExternalAuthResult.Success(info);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error validating Facebook token");
-            return ExternalAuthResult.Fail("Error validating Facebook token");
-        }
+        _logger.LogWarning("Unsupported provider {Provider}", provider);
+        return Task.FromResult(ExternalAuthResult.Fail("Unsupported provider"));
     }
 }

--- a/api/Avancira.Infrastructure/Auth/FacebookTokenValidator.cs
+++ b/api/Avancira.Infrastructure/Auth/FacebookTokenValidator.cs
@@ -1,0 +1,80 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Avancira.Application.Auth;
+using Avancira.Application.Options;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Avancira.Infrastructure.Auth;
+
+public class FacebookTokenValidator : IExternalTokenValidator
+{
+    private readonly HttpClient _httpClient;
+    private readonly FacebookOptions _options;
+    private readonly ILogger<FacebookTokenValidator> _logger;
+
+    public string Provider => "facebook";
+
+    public FacebookTokenValidator(
+        IHttpClientFactory httpClientFactory,
+        IOptions<FacebookOptions> facebookOptions,
+        ILogger<FacebookTokenValidator> logger)
+    {
+        _httpClient = httpClientFactory.CreateClient();
+        _options = facebookOptions.Value;
+        _logger = logger;
+    }
+
+    public async Task<ExternalAuthResult> ValidateAsync(string accessToken)
+    {
+        try
+        {
+            var appToken = $"{_options.AppId}|{_options.AppSecret}";
+            var debugResponse = await _httpClient.GetAsync($"https://graph.facebook.com/debug_token?input_token={accessToken}&access_token={appToken}");
+            if (!debugResponse.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Facebook debug_token request failed: {StatusCode}", debugResponse.StatusCode);
+                return ExternalAuthResult.Fail("Invalid Facebook token");
+            }
+
+            using var debugDoc = JsonDocument.Parse(await debugResponse.Content.ReadAsStringAsync());
+            var data = debugDoc.RootElement.GetProperty("data");
+            var appId = data.GetProperty("app_id").GetString();
+            var isValid = data.GetProperty("is_valid").GetBoolean();
+            var expiresAt = data.GetProperty("expires_at").GetInt64();
+            if (appId != _options.AppId || !isValid || DateTimeOffset.FromUnixTimeSeconds(expiresAt) <= DateTimeOffset.UtcNow)
+            {
+                _logger.LogWarning("Facebook token invalid: app_id={AppId} is_valid={IsValid} exp={Exp}", appId, isValid, expiresAt);
+                return ExternalAuthResult.Fail("Invalid Facebook token");
+            }
+
+            var profileResponse = await _httpClient.GetAsync($"https://graph.facebook.com/me?fields=id,name,email&access_token={accessToken}");
+            if (!profileResponse.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Facebook profile request failed: {StatusCode}", profileResponse.StatusCode);
+                return ExternalAuthResult.Fail("Unable to retrieve Facebook user info");
+            }
+
+            using var profileDoc = JsonDocument.Parse(await profileResponse.Content.ReadAsStringAsync());
+            var root = profileDoc.RootElement;
+            var id = root.GetProperty("id").GetString() ?? string.Empty;
+            var email = root.TryGetProperty("email", out var emailEl) ? emailEl.GetString() ?? string.Empty : string.Empty;
+            var name = root.TryGetProperty("name", out var nameEl) ? nameEl.GetString() ?? string.Empty : string.Empty;
+
+            var claims = new List<Claim>
+            {
+                new Claim(ClaimTypes.Email, email),
+                new Claim(ClaimTypes.Name, name)
+            };
+            var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "facebook"));
+            var info = new ExternalLoginInfo(principal, "Facebook", id, "Facebook");
+            return ExternalAuthResult.Success(info);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error validating Facebook token");
+            return ExternalAuthResult.Fail("Error validating Facebook token");
+        }
+    }
+}

--- a/api/Avancira.Infrastructure/Auth/GoogleTokenValidator.cs
+++ b/api/Avancira.Infrastructure/Auth/GoogleTokenValidator.cs
@@ -1,0 +1,68 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Avancira.Application.Auth;
+using Avancira.Application.Options;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Avancira.Infrastructure.Auth;
+
+public class GoogleTokenValidator : IExternalTokenValidator
+{
+    private readonly GoogleOptions _options;
+    private readonly ILogger<GoogleTokenValidator> _logger;
+
+    public string Provider => "google";
+
+    public GoogleTokenValidator(
+        IOptions<GoogleOptions> googleOptions,
+        ILogger<GoogleTokenValidator> logger)
+    {
+        _options = googleOptions.Value;
+        _logger = logger;
+    }
+
+    public Task<ExternalAuthResult> ValidateAsync(string idToken)
+    {
+        var handler = new JwtSecurityTokenHandler();
+        var parameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuers = new[] { "accounts.google.com", "https://accounts.google.com" },
+            ValidateAudience = true,
+            ValidAudience = _options.ClientId,
+            ValidateLifetime = true,
+            ClockSkew = TimeSpan.FromMinutes(5),
+            ValidateIssuerSigningKey = false
+        };
+
+        try
+        {
+            var principal = handler.ValidateToken(idToken, parameters, out _);
+            var sub = principal.FindFirstValue("sub") ?? string.Empty;
+            var email = principal.FindFirstValue(ClaimTypes.Email) ?? string.Empty;
+            var name = principal.FindFirstValue(ClaimTypes.Name) ?? string.Empty;
+
+            var claims = new List<Claim>
+            {
+                new Claim(ClaimTypes.Email, email),
+                new Claim(ClaimTypes.Name, name)
+            };
+            var identity = new ClaimsIdentity(claims, "google");
+            var info = new ExternalLoginInfo(new ClaimsPrincipal(identity), "Google", sub, "Google");
+            return Task.FromResult(ExternalAuthResult.Success(info));
+        }
+        catch (SecurityTokenException ex)
+        {
+            _logger.LogWarning(ex, "Google token validation failed");
+            return Task.FromResult(ExternalAuthResult.Fail("Invalid Google token"));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error validating Google token");
+            return Task.FromResult(ExternalAuthResult.Fail("Error validating Google token"));
+        }
+    }
+}

--- a/api/Avancira.Infrastructure/Auth/IExternalTokenValidator.cs
+++ b/api/Avancira.Infrastructure/Auth/IExternalTokenValidator.cs
@@ -1,0 +1,9 @@
+using Avancira.Application.Auth;
+
+namespace Avancira.Infrastructure.Auth;
+
+public interface IExternalTokenValidator
+{
+    string Provider { get; }
+    Task<ExternalAuthResult> ValidateAsync(string token);
+}

--- a/api/Avancira.Infrastructure/Common/Extensions.cs
+++ b/api/Avancira.Infrastructure/Common/Extensions.cs
@@ -52,7 +52,10 @@ namespace Avancira.Infrastructure.Catalog
             services.AddTransient<IWalletService, WalletService>();
             services.AddTransient<ILessonService, LessonService>();
             services.AddTransient<IJwtTokenService, JwtTokenService>();
-            services.AddHttpClient<IExternalAuthService, ExternalAuthService>();
+            services.AddHttpClient();
+            services.AddTransient<IExternalTokenValidator, GoogleTokenValidator>();
+            services.AddTransient<IExternalTokenValidator, FacebookTokenValidator>();
+            services.AddTransient<IExternalAuthService, ExternalAuthService>();
             services.AddTransient<IGeolocationService, GeolocationService>();
             services.AddTransient<IClientInfoService, ClientInfoService>();
             services.AddTransient<IFileUploadService, FileUploadService>();


### PR DESCRIPTION
## Summary
- add `IExternalTokenValidator` interface
- implement Google and Facebook token validators
- refactor `ExternalAuthService` to use registered token validators
- wire up validators in service collection and update tests

## Testing
- `dotnet test` *(fails: command not found)*
- `curl -sSL https://dot.net/v1/dotnet-install.sh` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a544f7208327bf4ccc23c324b6e2