### PR TITLE
Use DTOs for Facebook API responses and refine validation

### DIFF
--- a/api/Avancira.Infrastructure/Auth/FacebookDebugTokenResponse.cs
+++ b/api/Avancira.Infrastructure/Auth/FacebookDebugTokenResponse.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace Avancira.Infrastructure.Auth;
+
+public sealed class FacebookDebugTokenResponse
+{
+    [JsonPropertyName("data")]
+    public DebugData Data { get; init; } = new();
+
+    public sealed class DebugData
+    {
+        [JsonPropertyName("app_id")]
+        public string? AppId { get; init; }
+
+        [JsonPropertyName("is_valid")]
+        public bool IsValid { get; init; }
+
+        [JsonPropertyName("expires_at")]
+        public long ExpiresAt { get; init; }
+    }
+}

--- a/api/Avancira.Infrastructure/Auth/FacebookMeResponse.cs
+++ b/api/Avancira.Infrastructure/Auth/FacebookMeResponse.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Avancira.Infrastructure.Auth;
+
+public sealed class FacebookMeResponse
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("email")]
+    public string? Email { get; init; }
+}


### PR DESCRIPTION
## Summary
- add DTOs for Facebook `debug_token` and `me` responses
- deserialize Facebook responses into DTOs in `FacebookTokenValidator`
- distinguish network, JSON, and token validation failures with specific logs/messages

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b16fd4688327ad73b652158b7ed8