### PR TITLE
feat: centralize refresh token cookie helper

### DIFF
--- a/api/Avancira.API.Tests/BaseApiControllerTests.cs
+++ b/api/Avancira.API.Tests/BaseApiControllerTests.cs
@@ -1,0 +1,55 @@
+using Avancira.API.Controllers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using Xunit;
+
+public class BaseApiControllerTests
+{
+    private class TestController : BaseApiController
+    {
+        public void InvokeSetRefreshTokenCookie(string token, DateTime? expires)
+        {
+            SetRefreshTokenCookie(token, expires);
+        }
+    }
+
+    [Fact]
+    public void SetRefreshTokenCookie_WithExpiry_SetsCookieWithOptions()
+    {
+        var controller = new TestController();
+        var httpContext = new DefaultHttpContext();
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        var expires = DateTime.UtcNow.AddDays(1);
+
+        controller.InvokeSetRefreshTokenCookie("token123", expires);
+
+        var setCookie = httpContext.Response.Headers["Set-Cookie"].ToString().ToLowerInvariant();
+        setCookie.Should().Contain("refreshtoken=token123");
+        setCookie.Should().Contain("path=/api/auth");
+        setCookie.Should().Contain("httponly");
+        setCookie.Should().Contain("samesite=none");
+        setCookie.Should().Contain("secure");
+        setCookie.Should().Contain("expires=");
+    }
+
+    [Fact]
+    public void SetRefreshTokenCookie_WithoutExpiry_SetsSessionCookie()
+    {
+        var controller = new TestController();
+        var httpContext = new DefaultHttpContext();
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        controller.InvokeSetRefreshTokenCookie("token456", null);
+
+        var setCookie = httpContext.Response.Headers["Set-Cookie"].ToString().ToLowerInvariant();
+        setCookie.Should().Contain("refreshtoken=token456");
+        setCookie.Should().Contain("path=/api/auth");
+        setCookie.Should().Contain("httponly");
+        setCookie.Should().Contain("samesite=none");
+        setCookie.Should().Contain("secure");
+        setCookie.Should().NotContain("expires=");
+    }
+}

--- a/api/Avancira.API/Controllers/AuthController.cs
+++ b/api/Avancira.API/Controllers/AuthController.cs
@@ -100,22 +100,4 @@ public class AuthController : BaseApiController
         await _tokenService.RevokeSessionAsync(id, userId, cancellationToken);
         return Ok();
     }
-
-    private void SetRefreshTokenCookie(string refreshToken, DateTime? expires)
-    {
-        var cookieOptions = new CookieOptions
-        {
-            HttpOnly = true,
-            Secure = true,
-            SameSite = SameSiteMode.None,
-            Path = "/api/auth"
-        };
-
-        if (expires.HasValue)
-        {
-            cookieOptions.Expires = expires.Value;
-        }
-
-        Response.Cookies.Append("refreshToken", refreshToken, cookieOptions);
-    }
 }

--- a/api/Avancira.API/Controllers/BaseApiController.cs
+++ b/api/Avancira.API/Controllers/BaseApiController.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using System.Security.Claims;
+using System;
 
 namespace Avancira.API.Controllers;
 
@@ -51,5 +53,28 @@ public abstract class BaseApiController : ControllerBase
     protected bool HasRole(string role)
     {
         return User.IsInRole(role);
+    }
+
+    /// <summary>
+    /// Sets the refresh token cookie with standard options
+    /// </summary>
+    /// <param name="refreshToken">Refresh token value</param>
+    /// <param name="expires">Optional expiration time for persistent cookies</param>
+    protected void SetRefreshTokenCookie(string refreshToken, DateTime? expires)
+    {
+        var cookieOptions = new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = true,
+            SameSite = SameSiteMode.None,
+            Path = "/api/auth"
+        };
+
+        if (expires.HasValue)
+        {
+            cookieOptions.Expires = expires.Value;
+        }
+
+        Response.Cookies.Append("refreshToken", refreshToken, cookieOptions);
     }
 }

--- a/api/Avancira.API/Controllers/ExternalAuthController.cs
+++ b/api/Avancira.API/Controllers/ExternalAuthController.cs
@@ -106,21 +106,6 @@ public class ExternalAuthController : BaseApiController
         return Ok(new TokenResponse(tokens.Token));
     }
 
-    private void SetRefreshTokenCookie(string refreshToken, DateTime expires)
-    {
-        var cookieOptions = new CookieOptions
-        {
-            HttpOnly = true,
-            Secure = true,
-            SameSite = SameSiteMode.None,
-            Path = "/api/auth"
-        };
-
-        cookieOptions.Expires = expires;
-
-        Response.Cookies.Append("refreshToken", refreshToken, cookieOptions);
-    }
-
     public class ExternalLoginRequest
     {
         [Required]


### PR DESCRIPTION
## Summary
- add SetRefreshTokenCookie helper to BaseApiController
- use shared helper in AuthController and ExternalAuthController
- add unit tests for refresh token cookie helper

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*
- `curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh && bash dotnet-install.sh --version 9.0.100` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c57431ac832796856f0287f94d54