### PR TITLE
Centralize social authentication logic

### DIFF
--- a/Frontend.Angular/src/app/pages/signin/signin.component.html
+++ b/Frontend.Angular/src/app/pages/signin/signin.component.html
@@ -53,12 +53,12 @@
             </div>
             <div class="row form-row social-login">
               <div class="col-6">
-                <button class="btn btn-facebook btn-block w-100" (click)="loginWithFacebook()">
+                <button class="btn btn-facebook btn-block w-100" (click)="authenticate('facebook')">
                   <i class="fab fa-facebook-f me-1"></i> Login
                 </button>
               </div>
               <div class="col-6">
-                <button class="btn btn-google btn-block w-100" (click)="loginWithGoogle()">
+                <button class="btn btn-google btn-block w-100" (click)="authenticate('google')">
                   <i class="fab fa-google me-1"></i> Login
                 </button>
               </div>

--- a/Frontend.Angular/src/app/pages/signin/signin.component.spec.ts
+++ b/Frontend.Angular/src/app/pages/signin/signin.component.spec.ts
@@ -6,22 +6,22 @@ import { SigninComponent } from './signin.component';
 import { AuthService } from '../../services/auth.service';
 import { SpinnerService } from '../../services/spinner.service';
 import { ToastrService } from 'ngx-toastr';
-import { ConfigService } from '../../services/config.service';
 import { AlertService } from '../../services/alert.service';
 import { UserService } from '../../services/user.service';
-import { GoogleAuthService } from '../../services/google-auth.service';
-import { FacebookService } from 'ngx-facebook';
+import { SocialAuthService } from '../../services/social-auth.service';
 
 describe('LoginComponent', () => {
   let component: SigninComponent;
   let fixture: ComponentFixture<SigninComponent>;
   let authService: jasmine.SpyObj<AuthService>;
+  let socialAuth: jasmine.SpyObj<SocialAuthService>;
   let router: jasmine.SpyObj<Router>;
   let spinner: jasmine.SpyObj<SpinnerService>;
   let toastr: jasmine.SpyObj<ToastrService>;
 
   beforeEach(async () => {
-    authService = jasmine.createSpyObj('AuthService', ['externalLogin']);
+    authService = jasmine.createSpyObj('AuthService', ['login']);
+    socialAuth = jasmine.createSpyObj('SocialAuthService', ['authenticate']);
     router = jasmine.createSpyObj('Router', ['navigateByUrl']);
     spinner = jasmine.createSpyObj('SpinnerService', ['show', 'hide']);
     toastr = jasmine.createSpyObj('ToastrService', ['error']);
@@ -30,15 +30,13 @@ describe('LoginComponent', () => {
       imports: [SigninComponent],
       providers: [
         { provide: AuthService, useValue: authService },
+        { provide: SocialAuthService, useValue: socialAuth },
         { provide: Router, useValue: router },
         { provide: SpinnerService, useValue: spinner },
         { provide: ToastrService, useValue: toastr },
         { provide: ActivatedRoute, useValue: { queryParams: of({}) } },
-        { provide: ConfigService, useValue: { loadConfig: () => of({}), get: () => '' } },
         { provide: AlertService, useValue: {} },
         { provide: UserService, useValue: {} },
-        { provide: GoogleAuthService, useValue: {} },
-        { provide: FacebookService, useValue: { init: () => {} } },
       ],
     }).compileComponents();
 
@@ -52,20 +50,20 @@ describe('LoginComponent', () => {
   });
 
   it('should navigate to returnUrl on successful social login', () => {
-    authService.externalLogin.and.returnValue(of({} as any));
+    socialAuth.authenticate.and.returnValue(of({} as any));
     component.returnUrl = '/home';
 
-    component.handleSocialLogin('google', 'token123');
+    component.authenticate('google');
 
-    expect(authService.externalLogin).toHaveBeenCalledWith('google', 'token123');
+    expect(socialAuth.authenticate).toHaveBeenCalledWith('google');
     expect(router.navigateByUrl).toHaveBeenCalledWith('/home');
     expect(spinner.hide).toHaveBeenCalled();
   });
 
   it('should show error toast and hide spinner on social login error', () => {
-    authService.externalLogin.and.returnValue(throwError(() => new Error('fail')));
+    socialAuth.authenticate.and.returnValue(throwError(() => new Error('fail')));
 
-    component.handleSocialLogin('google', 'token123');
+    component.authenticate('google');
 
     expect(toastr.error).toHaveBeenCalled();
     expect(spinner.hide).toHaveBeenCalled();

--- a/Frontend.Angular/src/app/pages/signup/signup.component.html
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.html
@@ -176,12 +176,12 @@
             </div>
             <div class="row form-row social-login">
               <div class="col-6">
-                <button class="btn btn-facebook btn-block w-100" (click)="signupWithFacebook()">
+                <button class="btn btn-facebook btn-block w-100" (click)="authenticate('facebook')">
                   <i class="fab fa-facebook-f me-1"></i> Signup
                 </button>
               </div>
               <div class="col-6">
-                <button class="btn btn-google btn-block w-100" (click)="signupWithGoogle()">
+                <button class="btn btn-google btn-block w-100" (click)="authenticate('google')">
                   <i class="fab fa-google me-1"></i> Signup
                 </button>
               </div>

--- a/Frontend.Angular/src/app/pages/signup/signup.component.spec.ts
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.spec.ts
@@ -6,20 +6,20 @@ import { SignupComponent } from './signup.component';
 import { AuthService } from '../../services/auth.service';
 import { SpinnerService } from '../../services/spinner.service';
 import { ToastrService } from 'ngx-toastr';
-import { ConfigService } from '../../services/config.service';
-import { GoogleAuthService } from '../../services/google-auth.service';
-import { FacebookService } from 'ngx-facebook';
+import { SocialAuthService } from '../../services/social-auth.service';
 
 describe('SignupComponent', () => {
   let component: SignupComponent;
   let fixture: ComponentFixture<SignupComponent>;
   let authService: jasmine.SpyObj<AuthService>;
+  let socialAuth: jasmine.SpyObj<SocialAuthService>;
   let router: jasmine.SpyObj<Router>;
   let spinner: jasmine.SpyObj<SpinnerService>;
   let toastr: jasmine.SpyObj<ToastrService>;
 
   beforeEach(async () => {
-    authService = jasmine.createSpyObj('AuthService', ['externalLogin']);
+    authService = jasmine.createSpyObj('AuthService', ['register']);
+    socialAuth = jasmine.createSpyObj('SocialAuthService', ['authenticate']);
     router = jasmine.createSpyObj('Router', ['navigateByUrl']);
     spinner = jasmine.createSpyObj('SpinnerService', ['show', 'hide']);
     toastr = jasmine.createSpyObj('ToastrService', ['error']);
@@ -28,13 +28,11 @@ describe('SignupComponent', () => {
       imports: [SignupComponent],
       providers: [
         { provide: AuthService, useValue: authService },
+        { provide: SocialAuthService, useValue: socialAuth },
         { provide: Router, useValue: router },
         { provide: SpinnerService, useValue: spinner },
         { provide: ToastrService, useValue: toastr },
         { provide: ActivatedRoute, useValue: { queryParams: of({}) } },
-        { provide: ConfigService, useValue: { loadConfig: () => of({}), get: () => '' } },
-        { provide: GoogleAuthService, useValue: {} },
-        { provide: FacebookService, useValue: { init: () => {} } },
       ],
     }).compileComponents();
 
@@ -48,20 +46,20 @@ describe('SignupComponent', () => {
   });
 
   it('should navigate to returnUrl on successful social signup', () => {
-    authService.externalLogin.and.returnValue(of({} as any));
+    socialAuth.authenticate.and.returnValue(of({} as any));
     component.returnUrl = '/home';
 
-    component.handleSocialSignup('google', 'token123');
+    component.authenticate('google');
 
-    expect(authService.externalLogin).toHaveBeenCalledWith('google', 'token123');
+    expect(socialAuth.authenticate).toHaveBeenCalledWith('google');
     expect(router.navigateByUrl).toHaveBeenCalledWith('/home');
     expect(spinner.hide).toHaveBeenCalled();
   });
 
   it('should show error toast and hide spinner on social signup error', () => {
-    authService.externalLogin.and.returnValue(throwError(() => new Error('fail')));
+    socialAuth.authenticate.and.returnValue(throwError(() => new Error('fail')));
 
-    component.handleSocialSignup('google', 'token123');
+    component.authenticate('google');
 
     expect(toastr.error).toHaveBeenCalled();
     expect(spinner.hide).toHaveBeenCalled();

--- a/Frontend.Angular/src/app/services/social-auth.service.ts
+++ b/Frontend.Angular/src/app/services/social-auth.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@angular/core';
+import { FacebookService, InitParams } from 'ngx-facebook';
+import { Observable, from } from 'rxjs';
+import { switchMap, take, tap } from 'rxjs/operators';
+
+import { AuthService } from './auth.service';
+import { ConfigService } from './config.service';
+import { GoogleAuthService } from './google-auth.service';
+import { UserProfile } from '../models/UserProfile';
+
+@Injectable({ providedIn: 'root' })
+export class SocialAuthService {
+  private facebookInitialized = false;
+
+  constructor(
+    private google: GoogleAuthService,
+    private facebook: FacebookService,
+    private config: ConfigService,
+    private auth: AuthService
+  ) {}
+
+  authenticate(provider: 'google' | 'facebook'): Observable<UserProfile> {
+    if (provider === 'google') {
+      return this.config.loadConfig().pipe(
+        take(1),
+        switchMap(() => from(this.google.init(this.config.get('googleClientId')))),
+        switchMap(() => from(this.google.signIn())),
+        switchMap((token) => this.auth.externalLogin('google', token))
+      );
+    }
+
+    return this.config.loadConfig().pipe(
+      take(1),
+      tap(() => {
+        if (!this.facebookInitialized) {
+          const params: InitParams = {
+            appId: this.config.get('facebookAppId'),
+            cookie: true,
+            xfbml: true,
+            version: 'v21.0',
+          };
+          this.facebook.init(params);
+          this.facebookInitialized = true;
+        }
+      }),
+      switchMap(() => from(this.facebook.login({ scope: 'email,public_profile' }))),
+      switchMap((res) =>
+        this.auth.externalLogin('facebook', res.authResponse.accessToken)
+      )
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable `SocialAuthService` that wraps Google and Facebook SDKs and calls backend
- refactor sign-in and sign-up components to use `SocialAuthService.authenticate()`
- update unit tests to mock social auth service

## Testing
- `npm test` *(fails: Can't resolve './video-call-window.component.css?ngResource', and other missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c581807c8327bb3279070273faad