### PR TITLE
refactor: centralize facebook auth init

### DIFF
--- a/Frontend.Angular/src/app/pages/signin/signin.component.spec.ts
+++ b/Frontend.Angular/src/app/pages/signin/signin.component.spec.ts
@@ -9,12 +9,14 @@ import { ToastrService } from 'ngx-toastr';
 import { AlertService } from '../../services/alert.service';
 import { UserService } from '../../services/user.service';
 import { SocialAuthService } from '../../services/social-auth.service';
+import { FacebookAuthService } from '../../services/facebook-auth.service';
 
 describe('LoginComponent', () => {
   let component: SigninComponent;
   let fixture: ComponentFixture<SigninComponent>;
   let authService: jasmine.SpyObj<AuthService>;
   let socialAuth: jasmine.SpyObj<SocialAuthService>;
+  let facebookAuth: jasmine.SpyObj<FacebookAuthService>;
   let router: jasmine.SpyObj<Router>;
   let spinner: jasmine.SpyObj<SpinnerService>;
   let toastr: jasmine.SpyObj<ToastrService>;
@@ -22,6 +24,7 @@ describe('LoginComponent', () => {
   beforeEach(async () => {
     authService = jasmine.createSpyObj('AuthService', ['login']);
     socialAuth = jasmine.createSpyObj('SocialAuthService', ['authenticate']);
+    facebookAuth = jasmine.createSpyObj('FacebookAuthService', ['ensureInitialized']);
     router = jasmine.createSpyObj('Router', ['navigateByUrl']);
     spinner = jasmine.createSpyObj('SpinnerService', ['show', 'hide']);
     toastr = jasmine.createSpyObj('ToastrService', ['error']);
@@ -31,6 +34,7 @@ describe('LoginComponent', () => {
       providers: [
         { provide: AuthService, useValue: authService },
         { provide: SocialAuthService, useValue: socialAuth },
+        { provide: FacebookAuthService, useValue: facebookAuth },
         { provide: Router, useValue: router },
         { provide: SpinnerService, useValue: spinner },
         { provide: ToastrService, useValue: toastr },

--- a/Frontend.Angular/src/app/pages/signup/signup.component.spec.ts
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.spec.ts
@@ -7,12 +7,14 @@ import { AuthService } from '../../services/auth.service';
 import { SpinnerService } from '../../services/spinner.service';
 import { ToastrService } from 'ngx-toastr';
 import { SocialAuthService } from '../../services/social-auth.service';
+import { FacebookAuthService } from '../../services/facebook-auth.service';
 
 describe('SignupComponent', () => {
   let component: SignupComponent;
   let fixture: ComponentFixture<SignupComponent>;
   let authService: jasmine.SpyObj<AuthService>;
   let socialAuth: jasmine.SpyObj<SocialAuthService>;
+  let facebookAuth: jasmine.SpyObj<FacebookAuthService>;
   let router: jasmine.SpyObj<Router>;
   let spinner: jasmine.SpyObj<SpinnerService>;
   let toastr: jasmine.SpyObj<ToastrService>;
@@ -20,6 +22,7 @@ describe('SignupComponent', () => {
   beforeEach(async () => {
     authService = jasmine.createSpyObj('AuthService', ['register']);
     socialAuth = jasmine.createSpyObj('SocialAuthService', ['authenticate']);
+    facebookAuth = jasmine.createSpyObj('FacebookAuthService', ['ensureInitialized']);
     router = jasmine.createSpyObj('Router', ['navigateByUrl']);
     spinner = jasmine.createSpyObj('SpinnerService', ['show', 'hide']);
     toastr = jasmine.createSpyObj('ToastrService', ['error']);
@@ -29,6 +32,7 @@ describe('SignupComponent', () => {
       providers: [
         { provide: AuthService, useValue: authService },
         { provide: SocialAuthService, useValue: socialAuth },
+        { provide: FacebookAuthService, useValue: facebookAuth },
         { provide: Router, useValue: router },
         { provide: SpinnerService, useValue: spinner },
         { provide: ToastrService, useValue: toastr },

--- a/Frontend.Angular/src/app/services/facebook-auth.service.ts
+++ b/Frontend.Angular/src/app/services/facebook-auth.service.ts
@@ -1,0 +1,40 @@
+// src/app/services/facebook-auth.service.ts
+import { Injectable } from '@angular/core';
+import { FacebookService, InitParams, LoginResponse } from 'ngx-facebook';
+import { firstValueFrom } from 'rxjs';
+
+import { ConfigService } from './config.service';
+
+@Injectable({ providedIn: 'root' })
+export class FacebookAuthService {
+  private initPromise: Promise<void> | null = null;
+
+  constructor(
+    private fb: FacebookService,
+    private config: ConfigService
+  ) {}
+
+  /** Ensures the Facebook SDK is initialized */
+  ensureInitialized(): Promise<void> {
+    if (!this.initPromise) {
+      this.initPromise = firstValueFrom(this.config.loadConfig()).then(() => {
+        const params: InitParams = {
+          appId: this.config.get('facebookAppId'),
+          cookie: true,
+          xfbml: true,
+          version: 'v21.0',
+        };
+        this.fb.init(params);
+      });
+    }
+    return this.initPromise;
+  }
+
+  /** Performs Facebook login and resolves the access token */
+  async login(): Promise<string> {
+    await this.ensureInitialized();
+    const res: LoginResponse = await this.fb.login({ scope: 'email,public_profile' });
+    return res.authResponse.accessToken;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add FacebookAuthService to load config and init SDK once
- switch SocialAuthService and auth components to use FacebookAuthService
- pre-initialize Facebook SDK from sign-in and sign-up flows

## Testing
- `npm test -- --browsers=ChromeHeadless --watch=false` *(fails: Module not found: Can't resolve './video-call-window.component.css?ngResource')*


------
https://chatgpt.com/codex/tasks/task_e_68a8cb3496b88327b3815335a31fb488