### PR TITLE
feat: extract social login buttons component

### DIFF
--- a/Frontend.Angular/src/app/components/social-login-buttons/social-login-buttons.component.html
+++ b/Frontend.Angular/src/app/components/social-login-buttons/social-login-buttons.component.html
@@ -1,0 +1,12 @@
+<div class="row form-row social-login">
+  <div class="col-6">
+    <button class="btn btn-facebook btn-block w-100" (click)="facebook.emit()">
+      <i class="fab fa-facebook-f me-1"></i> {{ label }}
+    </button>
+  </div>
+  <div class="col-6">
+    <button class="btn btn-google btn-block w-100" (click)="google.emit()">
+      <i class="fab fa-google me-1"></i> {{ label }}
+    </button>
+  </div>
+</div>

--- a/Frontend.Angular/src/app/components/social-login-buttons/social-login-buttons.component.ts
+++ b/Frontend.Angular/src/app/components/social-login-buttons/social-login-buttons.component.ts
@@ -1,0 +1,14 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-social-login-buttons',
+  imports: [CommonModule],
+  templateUrl: './social-login-buttons.component.html',
+  styleUrl: './social-login-buttons.component.scss'
+})
+export class SocialLoginButtonsComponent {
+  @Output() google = new EventEmitter<void>();
+  @Output() facebook = new EventEmitter<void>();
+  @Input() label: string = 'Login';
+}

--- a/Frontend.Angular/src/app/pages/signin/signin.component.html
+++ b/Frontend.Angular/src/app/pages/signin/signin.component.html
@@ -51,18 +51,7 @@
               <span class="or-line"></span>
               <span class="span-or">or</span>
             </div>
-            <div class="row form-row social-login">
-              <div class="col-6">
-                <button class="btn btn-facebook btn-block w-100" (click)="authenticate('facebook')">
-                  <i class="fab fa-facebook-f me-1"></i> Login
-                </button>
-              </div>
-              <div class="col-6">
-                <button class="btn btn-google btn-block w-100" (click)="authenticate('google')">
-                  <i class="fab fa-google me-1"></i> Login
-                </button>
-              </div>
-            </div>
+            <app-social-login-buttons (google)="authenticate('google')" (facebook)="authenticate('facebook')" [label]="'Login'"></app-social-login-buttons>
 
             <div class="text-center dont-have">Don’t have an account? <a href="/signup">Register</a></div>
           </form>

--- a/Frontend.Angular/src/app/pages/signin/signin.component.ts
+++ b/Frontend.Angular/src/app/pages/signin/signin.component.ts
@@ -13,12 +13,13 @@ import { SocialAuthService } from '../../services/social-auth.service';
 import { SpinnerService } from '../../services/spinner.service';
 import { UserService } from '../../services/user.service';
 import { FacebookAuthService } from '../../services/facebook-auth.service';
+import { SocialLoginButtonsComponent } from '../../components/social-login-buttons/social-login-buttons.component';
 
 @Component({
   selector: 'app-signin',
   templateUrl: './signin.component.html',
   styleUrls: ['./signin.component.scss'],
-  imports: [CommonModule, ReactiveFormsModule, RouterModule]
+  imports: [CommonModule, ReactiveFormsModule, RouterModule, SocialLoginButtonsComponent]
 })
 export class SigninComponent implements OnInit {
   loginForm!: FormGroup;

--- a/Frontend.Angular/src/app/pages/signup/signup.component.html
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.html
@@ -174,18 +174,7 @@
               <span class="or-line"></span>
               <span class="span-or">or</span>
             </div>
-            <div class="row form-row social-login">
-              <div class="col-6">
-                <button class="btn btn-facebook btn-block w-100" (click)="authenticate('facebook')">
-                  <i class="fab fa-facebook-f me-1"></i> Signup
-                </button>
-              </div>
-              <div class="col-6">
-                <button class="btn btn-google btn-block w-100" (click)="authenticate('google')">
-                  <i class="fab fa-google me-1"></i> Signup
-                </button>
-              </div>
-            </div>
+            <app-social-login-buttons (google)="authenticate('google')" (facebook)="authenticate('facebook')" [label]="'Signup'"></app-social-login-buttons>
 
             <div class="account-footer text-center mt-3">
               Already have an account? <a class="forgot-link mb-0" routerLink="/signin">Login</a>

--- a/Frontend.Angular/src/app/pages/signup/signup.component.ts
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.ts
@@ -22,6 +22,7 @@ import { passwordComplexityValidator } from '../../validators/password.validator
 import { MIN_PASSWORD_LENGTH } from '../../validators/password-rules';
 import { RegisterUserRequest } from '../../models/register-user-request';
 import { FacebookAuthService } from '../../services/facebook-auth.service';
+import { SocialLoginButtonsComponent } from '../../components/social-login-buttons/social-login-buttons.component';
 
 interface SignupForm {
   firstName: FormControl<string>;
@@ -39,7 +40,7 @@ interface SignupForm {
   selector: 'app-signup',
   templateUrl: './signup.component.html',
   styleUrls: ['./signup.component.scss'],
-  imports: [CommonModule, ReactiveFormsModule, RouterModule]
+  imports: [CommonModule, ReactiveFormsModule, RouterModule, SocialLoginButtonsComponent]
 })
 export class SignupComponent implements OnInit, OnDestroy {
   signupForm: FormGroup<SignupForm>;


### PR DESCRIPTION
## Summary
- add reusable social login buttons component emitting google and facebook events
- replace duplicated social login markup in signin and signup pages

## Testing
- `npm test` *(fails: npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d62a4d4883278fc700969a27e4e2