### PR TITLE
Simplify Google Sign-In notification handling

### DIFF
--- a/Frontend.Angular/src/app/services/google-auth.service.ts
+++ b/Frontend.Angular/src/app/services/google-auth.service.ts
@@ -67,23 +67,15 @@ export class GoogleAuthService {
 
       try {
         google.accounts.id.prompt((notification: any) => {
+          console.log(notification);
           if (notification.isNotDisplayed()) {
-            const reason = notification.getNotDisplayedReason?.();
-            this.rejectFn?.(
-              `Google Sign-In not displayed${reason ? `: ${reason}` : ''}.`,
-            );
+            this.rejectFn?.('Google Sign-In not displayed.');
             this.clearHandlers();
           } else if (notification.isDismissed()) {
-            const reason = notification.getDismissedReason?.();
-            this.rejectFn?.(
-              `Google Sign-In dismissed${reason ? `: ${reason}` : ''}.`,
-            );
+            this.rejectFn?.('Google Sign-In dismissed.');
             this.clearHandlers();
           } else if (notification.isSkippedMoment()) {
-            const reason = notification.getSkippedReason?.();
-            this.rejectFn?.(
-              `Google Sign-In skipped${reason ? `: ${reason}` : ''}.`,
-            );
+            this.rejectFn?.('Google Sign-In skipped.');
             this.clearHandlers();
           } else if (notification.isDisplayed?.()) {
             // Sign-in prompt displayed successfully; actual resolution happens in callback


### PR DESCRIPTION
## Summary
- Remove usage of deprecated Google Identity notification reason getters
- Report generic sign-in status messages and log the notification for inspection

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Error: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_68ab08c3b78483279f6e64098bb79cf8