### PR TITLE
refactor: type google prompt callback

### DIFF
--- a/Frontend.Angular/src/app/services/google-auth.service.ts
+++ b/Frontend.Angular/src/app/services/google-auth.service.ts
@@ -66,21 +66,23 @@ export class GoogleAuthService {
       };
 
       try {
-        google.accounts.id.prompt((notification: any) => {
-          console.log(notification);
-          if (notification.isNotDisplayed()) {
-            this.rejectFn?.('Google Sign-In not displayed.');
-            this.clearHandlers();
-          } else if (notification.isDismissedMoment()) {
-            this.rejectFn?.('Google Sign-In dismissed.');
-            this.clearHandlers();
-          } else if (notification.isSkippedMoment()) {
-            this.rejectFn?.('Google Sign-In skipped.');
-            this.clearHandlers();
-          } else if (!notification.isNotDisplayed()) {
-            // Sign-in prompt displayed successfully; actual resolution happens in callback
-          }
-        });
+        google.accounts.id.prompt(
+          (notification: google.accounts.id.PromptMomentNotification) => {
+            console.log(notification);
+            if (notification.isNotDisplayed()) {
+              this.rejectFn?.('Google Sign-In not displayed.');
+              this.clearHandlers();
+            } else if (notification.isDismissedMoment()) {
+              this.rejectFn?.('Google Sign-In dismissed.');
+              this.clearHandlers();
+            } else if (notification.isSkippedMoment()) {
+              this.rejectFn?.('Google Sign-In skipped.');
+              this.clearHandlers();
+            } else if (!notification.isNotDisplayed()) {
+              // Sign-in prompt displayed successfully; actual resolution happens in callback
+            }
+          },
+        );
       } catch (e) {
         this.rejectFn?.(e);
         this.clearHandlers();


### PR DESCRIPTION
## Summary
- add typed PromptMomentNotification to Google sign-in prompt

## Testing
- `npm run build` *(fails: Could not resolve "jwt-decode"; Namespace 'google' has no exported member 'accounts'; Failed to inline external stylesheet 'https://fonts.googleapis.com/css...')*

------
https://chatgpt.com/codex/tasks/task_e_68ab0c7df1148327a4945b8b837757ca