### PR TITLE
Use FedCM prompt without callback

### DIFF
--- a/Frontend.Angular/src/app/services/google-auth.service.ts
+++ b/Frontend.Angular/src/app/services/google-auth.service.ts
@@ -65,15 +65,8 @@ export class GoogleAuthService {
       };
 
       try {
-        // Prompt callback is advisory under FedCM. Don’t branch on removed display-moment APIs.
-        google.accounts.id.prompt((notification: any) => {
-          // If the user explicitly dismisses the UI, fail fast.
-          if (notification?.isDismissedMoment?.()) {
-            this.rejectFn?.('Google Sign-In dismissed.');
-            this.clearHandlers();
-          }
-          // If skipped, just keep waiting for the global credential callback or the timeout.
-        });
+        // Prompt without a callback. Any dismissal will be handled by the timeout or global credential callback.
+        google.accounts.id.prompt();
       } catch (e) {
         this.rejectFn?.(e);
         this.clearHandlers();


### PR DESCRIPTION
## Summary
- call `google.accounts.id.prompt()` without callback and rely on credential callback or timeout

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: export and module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab145486e08327af33253000c502cb