### PR TITLE
refactor: replace social login provider

### DIFF
--- a/Frontend.Angular/src/app/app.config.ts
+++ b/Frontend.Angular/src/app/app.config.ts
@@ -10,7 +10,7 @@ import { provideRouter } from '@angular/router';
 import { catchError, firstValueFrom, of } from 'rxjs';
 import { provideToastr } from 'ngx-toastr';
 import {
-  provideSocialLogin,
+  provideSocialAuthServiceConfig,
   GoogleLoginProvider,
   FacebookLoginProvider,
 } from '@abacritt/angularx-social-login';
@@ -52,7 +52,7 @@ export const appConfig: ApplicationConfig = {
 
     provideAnimationsAsync(),
 
-    provideSocialLogin(() => ({
+    provideSocialAuthServiceConfig(() => ({
       autoLogin: false,
       providers: [
         {


### PR DESCRIPTION
## Summary
- replace deprecated provideSocialLogin import with provideSocialAuthServiceConfig
- update application config to use provideSocialAuthServiceConfig provider

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@abacritt%2fangularx-social-login)*
- `npm start` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2c1b78548327b2bfc01dd9b5d50e