### PR TITLE
fix: reference scss for video call component

### DIFF
--- a/Frontend.Angular/src/app/components/video-call-window/video-call-window.component.ts
+++ b/Frontend.Angular/src/app/components/video-call-window/video-call-window.component.ts
@@ -9,7 +9,7 @@ declare var JitsiMeetExternalAPI: any;
 @Component({
   selector: 'app-video-call-window',
   templateUrl: './video-call-window.component.html',
-  styleUrls: ['./video-call-window.component.css']
+  styleUrls: ['./video-call-window.component.scss']
 })
 export class VideoCallWindowComponent implements OnInit, OnDestroy {
   private jitsiApi: any | null = null;


### PR DESCRIPTION
## Summary
- point `video-call-window` component to its `.scss` stylesheet

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run build` *(fails: Cannot resolve '@abacritt/angularx-social-login')*

------
https://chatgpt.com/codex/tasks/task_e_68ab2c2a922083279d1cff8dd0261109