### PR TITLE
Configure social login provider for existing library

### DIFF
--- a/Frontend.Angular/src/app/app.config.ts
+++ b/Frontend.Angular/src/app/app.config.ts
@@ -10,7 +10,7 @@ import { provideRouter } from '@angular/router';
 import { catchError, firstValueFrom, of } from 'rxjs';
 import { provideToastr } from 'ngx-toastr';
 import {
-  provideSocialAuthServiceConfig,
+  SocialAuthServiceConfig,
   GoogleLoginProvider,
   FacebookLoginProvider,
 } from '@abacritt/angularx-social-login';
@@ -52,23 +52,27 @@ export const appConfig: ApplicationConfig = {
 
     provideAnimationsAsync(),
 
-    provideSocialAuthServiceConfig(() => ({
-      autoLogin: false,
-      providers: [
-        {
-          id: GoogleLoginProvider.PROVIDER_ID,
-          provider: new GoogleLoginProvider(
-            inject(ConfigService).get(ConfigKey.GoogleClientId)
-          ),
-        },
-        {
-          id: FacebookLoginProvider.PROVIDER_ID,
-          provider: new FacebookLoginProvider(
-            inject(ConfigService).get(ConfigKey.FacebookAppId)
-          ),
-        },
-      ],
-    })),
+    {
+      provide: 'SocialAuthServiceConfig',
+      useFactory: () =>
+        ({
+          autoLogin: false,
+          providers: [
+            {
+              id: GoogleLoginProvider.PROVIDER_ID,
+              provider: new GoogleLoginProvider(
+                inject(ConfigService).get(ConfigKey.GoogleClientId)
+              ),
+            },
+            {
+              id: FacebookLoginProvider.PROVIDER_ID,
+              provider: new FacebookLoginProvider(
+                inject(ConfigService).get(ConfigKey.FacebookAppId)
+              ),
+            },
+          ],
+        }) as SocialAuthServiceConfig,
+    },
 
     provideAppInitializer(initAuth),
   ]


### PR DESCRIPTION
## Summary
- use `SocialAuthServiceConfig` provider instead of `provideSocialAuthServiceConfig`

## Testing
- `npm run build` *(fails: Failed to inline external stylesheet 'https://fonts.googleapis.com/css?family=Poppins:300,400,500,700,900'.)*
- `./node_modules/.bin/ng test --watch=false` *(failed: network access blocked for "ng" package or missing browser)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2e587ef48327bb46254502bf4651