### PR TITLE
feat: preload config before social auth

### DIFF
--- a/Frontend.Angular/src/app/app.config.ts
+++ b/Frontend.Angular/src/app/app.config.ts
@@ -23,6 +23,12 @@ import { routes } from './app.routes';
 import { authInterceptor } from './interceptors/auth.interceptor';
 import { dateInterceptorFn } from './interceptors/dateInterceptorFn';
 
+function initConfig() {
+  return firstValueFrom(
+    inject(ConfigService).loadConfig().pipe(catchError(() => of(null)))
+  );
+}
+
 function initAuth() {
   const auth = inject(AuthService);
   return firstValueFrom(
@@ -51,6 +57,8 @@ export const appConfig: ApplicationConfig = {
     }),
 
     provideAnimationsAsync(),
+
+    provideAppInitializer(initConfig),
 
     {
       provide: 'SocialAuthServiceConfig',


### PR DESCRIPTION
## Summary
- add app initializer to load remote ConfigService settings
- load config before registering SocialAuthServiceConfig so Google and Facebook IDs can be accessed

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: module errors and missing styles)*
- `npm run build` *(fails: missing modules and font fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3719108c8327986f3b74c5ae8dc1