### PR TITLE
feat(api): integrate openiddict with external providers

### DIFF
--- a/api/Avancira.API/Avancira.API.csproj
+++ b/api/Avancira.API/Avancira.API.csproj
@@ -25,6 +25,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="9.0.3" />
+    <PackageReference Include="OpenIddict.Server.AspNetCore" Version="5.*" />
+    <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="5.*" />
   </ItemGroup>
 
   


### PR DESCRIPTION
## Summary
- register OpenIddict with authorization code flow and PKCE
- route authorization requests through Google or Facebook
- validate issued tokens via OpenIddict's validation handler

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68adad847edc8327a63434e6f9990f92