### PR TITLE
Configure OpenIddict revocation and scopes

### DIFF
--- a/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
+++ b/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using OpenIddict.Server;
@@ -16,19 +17,24 @@ public static class OpenIddictSetup
             .AddServer(options =>
             {
                 options.SetAuthorizationEndpointUris("/connect/authorize")
-                       .SetTokenEndpointUris("/connect/token");
+                       .SetTokenEndpointUris("/connect/token")
+                       .SetRevocationEndpointUris("/connect/revocation")
+                       .SetIssuer(new Uri("https://localhost:9000/"));
 
                 options.AllowPasswordFlow()
                        .AllowRefreshTokenFlow()
                        .AllowAuthorizationCodeFlow()
                        .RequireProofKeyForCodeExchange();
 
+                options.RegisterScopes("api");
+
                 options.AddDevelopmentEncryptionCertificate()
                        .AddDevelopmentSigningCertificate();
 
                 options.UseAspNetCore()
                        .EnableAuthorizationEndpointPassthrough()
-                       .EnableTokenEndpointPassthrough();
+                       .EnableTokenEndpointPassthrough()
+                       .EnableRevocationEndpointPassthrough();
 
                 options.AddEventHandler<HandleAuthorizationRequestContext>(builder =>
                     builder.UseScopedHandler<ExternalLoginHandler>());


### PR DESCRIPTION
## Summary
- expose revocation endpoint and issuer for OpenIddict
- register API scope and enable revocation passthrough

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68add694eef48327865a165e86122321