### PR TITLE
Refactor authentication to authorization code flow

### DIFF
--- a/Frontend.Angular/src/app/interceptors/auth.interceptor.ts
+++ b/Frontend.Angular/src/app/interceptors/auth.interceptor.ts
@@ -17,7 +17,7 @@ import { environment } from '../environments/environment';
 
 /**
  * Bypass auth mechanics entirely for this request (no pre-wait, no Authorization, no 401 retry).
- * Use for /auth/token and /auth/refresh to avoid recursion.
+ * Use for /connect/token or other login endpoints to avoid recursion.
  */
 export const SKIP_AUTH = new HttpContextToken<boolean>(() => false);
 

--- a/Frontend.Angular/src/app/pages/signin/signin.component.spec.ts
+++ b/Frontend.Angular/src/app/pages/signin/signin.component.spec.ts
@@ -21,7 +21,7 @@ describe('LoginComponent', () => {
   let toastr: jasmine.SpyObj<ToastrService>;
 
   beforeEach(async () => {
-    authService = jasmine.createSpyObj('AuthService', ['login']);
+    authService = jasmine.createSpyObj('AuthService', ['startLogin']);
     socialAuth = jasmine.createSpyObj('SocialAuthService', ['authenticate']);
     router = jasmine.createSpyObj('Router', ['navigateByUrl']);
     spinner = jasmine.createSpyObj('SpinnerService', ['show', 'hide']);

--- a/Frontend.Angular/src/app/pages/signin/signin.component.ts
+++ b/Frontend.Angular/src/app/pages/signin/signin.component.ts
@@ -78,22 +78,7 @@ export class SigninComponent implements OnInit {
 
   /** Regular login */
   onLogin(): void {
-    if (this.loginForm.invalid) return;
-
-    const { email, password, rememberMe } = this.loginForm.value;
-    this.spinner.show();
-
-    this.authService
-      .login(email, password, rememberMe)
-      .pipe(finalize(() => this.spinner.hide()))
-      .subscribe({
-        next: () => {
-          this.router.navigateByUrl(this.sanitizeReturnUrl(this.returnUrl));
-        },
-        error: () => {
-          this.toastr.error('Invalid credentials', 'Login Failed');
-        },
-      });
+    void this.authService.startLogin(this.returnUrl);
   }
 
   authenticate(provider: SocialProvider): void {

--- a/Frontend.Angular/src/app/services/auth.service.spec.ts
+++ b/Frontend.Angular/src/app/services/auth.service.spec.ts
@@ -29,27 +29,6 @@ describe('AuthService', () => {
     http.verify();
   });
 
-  it('should set auth state and profile on login', (done) => {
-    const token = makeToken({ sub: '1', email: 'a@b.com', exp: Math.floor(Date.now() / 1000) + 3600 });
-
-    service.login('a@b.com', 'pw').subscribe(profile => {
-      expect(profile.email).toBe('a@b.com');
-      expect(profile.permissions).toEqual(['perm1']);
-      service.authState$.pipe(take(1)).subscribe(state => {
-        expect(state).toBe(AuthStateKind.Authenticated);
-        expect(service.isAuthenticated()).toBeTrue();
-        done();
-      });
-    });
-
-    const req = http.expectOne(`${environment.apiUrl}/auth/token`);
-    expect(req.request.method).toBe('POST');
-    req.flush({ token });
-
-    const perms = http.expectOne(`${environment.apiUrl}/users/permissions`);
-    perms.flush(['perm1']);
-  });
-
   it('should set auth state and profile on external login', (done) => {
     const token = makeToken({ sub: '2', email: 'c@d.com', exp: Math.floor(Date.now() / 1000) + 3600 });
 

--- a/api/Avancira.API/Controllers/AuthController.cs
+++ b/api/Avancira.API/Controllers/AuthController.cs
@@ -1,5 +1,4 @@
 using Avancira.Application.Identity;
-using Avancira.Application.Identity.Tokens.Dtos;
 using Avancira.Application.Auth;
 using Avancira.Application.Auth.Dtos;
 using System;
@@ -23,31 +22,6 @@ public class AuthController : BaseApiController
         _authenticationService = authenticationService;
         _externalAuthService = externalAuthService;
         _externalUserService = externalUserService;
-    }
-
-    [HttpPost("token")]
-    [AllowAnonymous]
-    public async Task<ActionResult<TokenResponse>> GenerateToken([FromBody] TokenGenerationDto request)
-    {
-        var pair = await _authenticationService.GenerateTokenAsync(request);
-        DateTime? expires = request.RememberMe ? pair.RefreshTokenExpiryTime : null;
-        SetRefreshTokenCookie(pair.RefreshToken, expires);
-        return Ok(new TokenResponse(pair.Token));
-    }
-
-    [HttpPost("refresh")]
-    [AllowAnonymous]
-    public async Task<ActionResult<TokenResponse>> RefreshToken([FromBody] RefreshTokenDto? request)
-    {
-        var refreshToken = request?.Token ?? Request.Cookies["refreshToken"];
-        if (string.IsNullOrWhiteSpace(refreshToken))
-        {
-            return Unauthorized();
-        }
-
-        var pair = await _authenticationService.RefreshTokenAsync(refreshToken);
-        SetRefreshTokenCookie(pair.RefreshToken, pair.RefreshTokenExpiryTime);
-        return Ok(new TokenResponse(pair.Token));
     }
 
     [HttpPost("external-login")]

--- a/api/Avancira.Application/Identity/IAuthenticationService.cs
+++ b/api/Avancira.Application/Identity/IAuthenticationService.cs
@@ -1,11 +1,8 @@
-using Avancira.Application.Identity.Tokens.Dtos;
-
 namespace Avancira.Application.Identity;
 
 public interface IAuthenticationService
 {
-    Task<TokenPair> GenerateTokenAsync(TokenGenerationDto request);
-    Task<TokenPair> RefreshTokenAsync(string refreshToken);
+    Task<TokenPair> ExchangeCodeAsync(string code, string codeVerifier, string redirectUri);
     Task<TokenPair> GenerateTokenAsync(string userId);
 }
 

--- a/api/Avancira.Infrastructure/Auth/AuthenticationService.cs
+++ b/api/Avancira.Infrastructure/Auth/AuthenticationService.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using System.Collections.Generic;
 using Avancira.Application.Common;
 using Avancira.Application.Identity;
-using Avancira.Application.Identity.Tokens.Dtos;
 using Avancira.Domain.Identity;
 using Avancira.Infrastructure.Persistence;
 using System.IdentityModel.Tokens.Jwt;
@@ -26,16 +25,16 @@ public class AuthenticationService : IAuthenticationService
         _dbContext = dbContext;
     }
 
-    public async Task<TokenPair> GenerateTokenAsync(TokenGenerationDto request)
+    public async Task<TokenPair> ExchangeCodeAsync(string code, string codeVerifier, string redirectUri)
     {
         var clientInfo = await _clientInfoService.GetClientInfoAsync();
 
         var content = new FormUrlEncodedContent(new Dictionary<string, string?>
         {
-            ["grant_type"] = "password",
-            ["username"] = request.Email,
-            ["password"] = request.Password,
-            ["scope"] = "api offline_access"
+            ["grant_type"] = "authorization_code",
+            ["code"] = code,
+            ["redirect_uri"] = redirectUri,
+            ["code_verifier"] = codeVerifier
         });
 
         var response = await _httpClient.PostAsync("/connect/token", content);
@@ -145,68 +144,6 @@ public class AuthenticationService : IAuthenticationService
 
         _dbContext.Sessions.Add(session);
         await _dbContext.SaveChangesAsync();
-
-        return new TokenPair(token, refresh, refreshExpiry);
-    }
-
-    public async Task<TokenPair> RefreshTokenAsync(string refreshToken)
-    {
-        var clientInfo = await _clientInfoService.GetClientInfoAsync();
-
-        var content = new FormUrlEncodedContent(new Dictionary<string, string?>
-        {
-            ["grant_type"] = "refresh_token",
-            ["refresh_token"] = refreshToken
-        });
-
-        var response = await _httpClient.PostAsync("/connect/token", content);
-        response.EnsureSuccessStatusCode();
-
-        using var stream = await response.Content.ReadAsStreamAsync();
-        using var document = await JsonDocument.ParseAsync(stream);
-        var root = document.RootElement;
-
-        var token = root.GetProperty("access_token").GetString() ?? string.Empty;
-        var refresh = root.GetProperty("refresh_token").GetString() ?? string.Empty;
-        DateTime refreshExpiry = DateTime.UtcNow;
-        if (root.TryGetProperty("refresh_token_expires_in", out var exp))
-        {
-            refreshExpiry = DateTime.UtcNow.AddSeconds(exp.GetInt32());
-        }
-        else
-        {
-            refreshExpiry = DateTime.UtcNow.AddDays(7);
-        }
-
-        var now = DateTime.UtcNow;
-        var hash = HashToken(refreshToken);
-        var existingToken = await _dbContext.RefreshTokens
-            .Include(r => r.Session)
-            .FirstOrDefaultAsync(r => r.TokenHash == hash);
-
-        if (existingToken != null)
-        {
-            existingToken.RevokedUtc = now;
-            var session = existingToken.Session;
-            session.LastRefreshUtc = now;
-            session.LastActivityUtc = now;
-            session.IpAddress = clientInfo.IpAddress;
-            session.UserAgent = clientInfo.UserAgent;
-            session.OperatingSystem = clientInfo.OperatingSystem;
-            session.Country = clientInfo.Country;
-            session.City = clientInfo.City;
-
-            _dbContext.RefreshTokens.Add(new RefreshToken
-            {
-                TokenHash = HashToken(refresh),
-                SessionId = session.Id,
-                RotatedFromId = existingToken.Id,
-                CreatedUtc = now,
-                AbsoluteExpiryUtc = refreshExpiry
-            });
-
-            await _dbContext.SaveChangesAsync();
-        }
 
         return new TokenPair(token, refresh, refreshExpiry);
     }

--- a/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
+++ b/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
@@ -21,8 +21,7 @@ public static class OpenIddictSetup
                        .SetRevocationEndpointUris("/connect/revocation")
                        .SetIssuer(new Uri("https://localhost:9000/"));
 
-                options.AllowPasswordFlow()
-                       .AllowRefreshTokenFlow()
+                options.AllowRefreshTokenFlow()
                        .AllowAuthorizationCodeFlow()
                        .RequireProofKeyForCodeExchange();
 


### PR DESCRIPTION
## Summary
- remove legacy /api/auth/token and /api/auth/refresh endpoints
- disable password grant in OpenIddict in favor of authorization code + PKCE
- implement authorization code + PKCE flow in client AuthService and backend exchange helper

## Testing
- `npm test` (fails: Module not found, missing dependencies)
- `dotnet test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ade7b822b88327a11cbf8edb177775