### PR TITLE
Include device and location claims in JWT and UI

### DIFF
--- a/Frontend.Angular/src/app/models/UserProfile.ts
+++ b/Frontend.Angular/src/app/models/UserProfile.ts
@@ -7,6 +7,9 @@ export interface UserProfile {
   timeZoneId?: string;
   ipAddress?: string;
   imageUrl?: string;
+  deviceId?: string;
+  country?: string;
+  city?: string;
   roles: string[];        // multiple roles
   permissions: string[];  // permissions as strings
   exp?: number;           // token expiration (epoch seconds)

--- a/Frontend.Angular/src/app/pages/profile/profile.component.html
+++ b/Frontend.Angular/src/app/pages/profile/profile.component.html
@@ -15,6 +15,10 @@
                 <form (ngSubmit)="saveProfile()" #profileForm="ngForm" novalidate enctype="multipart/form-data">
 
                     <div class="row form-row">
+                        <div class="col-12 mb-3">
+                            <p><strong>Device:</strong> {{ currentSession?.deviceId || 'N/A' }}</p>
+                            <p><strong>Location:</strong> {{ currentSession?.city || 'Unknown' }}, {{ currentSession?.country || 'Unknown' }}</p>
+                        </div>
                         <div class="col-12 col-md-12">
                             <div class="form-group">
                                 <div class="change-avatar">

--- a/Frontend.Angular/src/app/pages/profile/profile.component.ts
+++ b/Frontend.Angular/src/app/pages/profile/profile.component.ts
@@ -7,7 +7,7 @@ import { MapAddressComponent } from '../../components/map-address/map-address.co
 
 import { AlertService } from '../../services/alert.service';
 import { AuthService } from '../../services/auth.service';
-import { SpinnerService } from '../../services/spinner.service'; 
+import { SpinnerService } from '../../services/spinner.service';
 import { UserService } from '../../services/user.service';
 import { matchPasswords, passwordComplexityValidator } from '../../validators/password.validators';
 import { MIN_PASSWORD_LENGTH } from '../../validators/password-rules';
@@ -17,6 +17,7 @@ import { ImageFallbackDirective } from '../../directives/image-fallback.directiv
 import { UserDiplomaStatus } from '../../models/enums/user-diploma-status';
 
 import { Address, User } from '../../models/user';
+import { UserProfile } from '../../models/UserProfile';
 
 
 @Component({
@@ -36,6 +37,7 @@ export class ProfileComponent implements OnInit {
   profile: User = {} as User;
   profileImageFile: File | null = null;
   changePasswordForm: FormGroup;
+  currentSession?: UserProfile | null;
 
   // Notifications
   notifications = {
@@ -58,7 +60,7 @@ export class ProfileComponent implements OnInit {
 
   constructor(
     private alertService: AlertService,
-    private authService: AuthService,
+    public authService: AuthService,
     private userService: UserService,
     private spinnerService: SpinnerService,
     private router: Router,
@@ -88,6 +90,7 @@ export class ProfileComponent implements OnInit {
     this.fetchDiplomaStatus();
     this.loadUserProfile();
     this.loadTimezones();
+    this.currentSession = this.authService.decode();
   }
 
   loadTimezones(): void {

--- a/api/Avancira.Infrastructure/Auth/AuthenticationService.cs
+++ b/api/Avancira.Infrastructure/Auth/AuthenticationService.cs
@@ -34,7 +34,10 @@ public class AuthenticationService : IAuthenticationService
             ["grant_type"] = "authorization_code",
             ["code"] = code,
             ["redirect_uri"] = redirectUri,
-            ["code_verifier"] = codeVerifier
+            ["code_verifier"] = codeVerifier,
+            ["device_id"] = clientInfo.DeviceId,
+            ["country"] = clientInfo.Country,
+            ["city"] = clientInfo.City
         });
 
         var response = await _httpClient.PostAsync("/connect/token", content);
@@ -97,7 +100,10 @@ public class AuthenticationService : IAuthenticationService
         {
             ["grant_type"] = "user_id",
             ["user_id"] = userId,
-            ["scope"] = "api offline_access"
+            ["scope"] = "api offline_access",
+            ["device_id"] = clientInfo.DeviceId,
+            ["country"] = clientInfo.Country,
+            ["city"] = clientInfo.City
         });
 
         var response = await _httpClient.PostAsync("/connect/token", content);

--- a/api/Avancira.Infrastructure/Identity/DeviceInfoClaimsHandler.cs
+++ b/api/Avancira.Infrastructure/Identity/DeviceInfoClaimsHandler.cs
@@ -1,0 +1,37 @@
+using System.Threading.Tasks;
+using OpenIddict.Abstractions;
+using OpenIddict.Server;
+using OpenIddict.Server.Events;
+
+namespace Avancira.Infrastructure.Identity;
+
+public class DeviceInfoClaimsHandler : IOpenIddictServerHandler<ProcessSignInContext>
+{
+    public ValueTask HandleAsync(ProcessSignInContext context)
+    {
+        var request = context.Transaction?.Request;
+        if (request is null || context.Principal is null)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        var deviceId = (string?)request["device_id"];
+        var country = (string?)request["country"];
+        var city = (string?)request["city"];
+
+        if (!string.IsNullOrEmpty(deviceId))
+        {
+            context.Principal.SetClaim("device_id", deviceId);
+        }
+        if (!string.IsNullOrEmpty(country))
+        {
+            context.Principal.SetClaim("country", country);
+        }
+        if (!string.IsNullOrEmpty(city))
+        {
+            context.Principal.SetClaim("city", city);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
+++ b/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
@@ -37,6 +37,8 @@ public static class OpenIddictSetup
 
                 options.AddEventHandler<HandleAuthorizationRequestContext>(builder =>
                     builder.UseScopedHandler<ExternalLoginHandler>());
+                options.AddEventHandler<ProcessSignInContext>(builder =>
+                    builder.UseScopedHandler<DeviceInfoClaimsHandler>());
             })
             .AddValidation(options =>
             {


### PR DESCRIPTION
## Summary
- Add device, country, and city parameters when requesting tokens and attach them as claims via a new OpenIddict handler
- Parse device and location claims in the frontend and expose them through `AuthService.decode`
- Display current device and location on the profile page

## Testing
- `dotnet build` *(fails: command not found)*
- `npm test` *(fails: multiple missing modules and build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68adf2f15a908327bb1415bf2f20ae18