### PR TITLE
Add session revocation API

### DIFF
--- a/api/Avancira.API/Controllers/SessionsController.cs
+++ b/api/Avancira.API/Controllers/SessionsController.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using Avancira.Application.Identity.Tokens;
+using Avancira.Application.Identity.Tokens.Dtos;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Avancira.API.Controllers;
+
+[Route("api/auth/sessions")]
+public class SessionsController : BaseApiController
+{
+    private readonly ISender _mediator;
+
+    public SessionsController(ISender mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(List<SessionDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetSessions(CancellationToken cancellationToken)
+    {
+        var userId = GetUserId();
+        var sessions = await _mediator.Send(new GetSessionsQuery(userId), cancellationToken);
+        return Ok(sessions);
+    }
+
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> RevokeSession(Guid id, CancellationToken cancellationToken)
+    {
+        var userId = GetUserId();
+        await _mediator.Send(new RevokeSessionCommand(id, userId), cancellationToken);
+        return NoContent();
+    }
+}

--- a/api/Avancira.Application/Identity/Tokens/ISessionService.cs
+++ b/api/Avancira.Application/Identity/Tokens/ISessionService.cs
@@ -1,8 +1,11 @@
 using Avancira.Application.Identity.Tokens.Dtos;
+using System;
 
 namespace Avancira.Application.Identity.Tokens;
+
 
 public interface ISessionService
 {
     Task<List<SessionDto>> GetActiveSessionsAsync(string userId);
+    Task RevokeSessionAsync(string userId, Guid sessionId);
 }

--- a/api/Avancira.Application/Identity/Tokens/RevokeSessionCommand.cs
+++ b/api/Avancira.Application/Identity/Tokens/RevokeSessionCommand.cs
@@ -1,0 +1,22 @@
+using System;
+using MediatR;
+
+namespace Avancira.Application.Identity.Tokens;
+
+public record RevokeSessionCommand(Guid SessionId, string UserId) : IRequest;
+
+public class RevokeSessionCommandHandler : IRequestHandler<RevokeSessionCommand>
+{
+    private readonly ISessionService _sessionService;
+
+    public RevokeSessionCommandHandler(ISessionService sessionService)
+    {
+        _sessionService = sessionService;
+    }
+
+    public async Task<Unit> Handle(RevokeSessionCommand request, CancellationToken cancellationToken)
+    {
+        await _sessionService.RevokeSessionAsync(request.UserId, request.SessionId);
+        return Unit.Value;
+    }
+}


### PR DESCRIPTION
## Summary
- add controller for listing and revoking auth sessions
- support session revocation via new command and service methods

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adf7ea069c8327bca801eac4b99ed3