### PR TITLE
Add session revocation for multiple sessions

### DIFF
--- a/api/Avancira.Application/Identity/Tokens/ISessionService.cs
+++ b/api/Avancira.Application/Identity/Tokens/ISessionService.cs
@@ -1,5 +1,6 @@
 using Avancira.Application.Identity.Tokens.Dtos;
 using System;
+using System.Collections.Generic;
 
 namespace Avancira.Application.Identity.Tokens;
 
@@ -8,4 +9,5 @@ public interface ISessionService
 {
     Task<List<SessionDto>> GetActiveSessionsAsync(string userId);
     Task RevokeSessionAsync(string userId, Guid sessionId);
+    Task RevokeSessionsAsync(string userId, IEnumerable<Guid> sessionIds);
 }


### PR DESCRIPTION
## Summary
- add `RevokeSessionsAsync` to session service interface
- implement revocation of multiple sessions and related refresh tokens

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68adfeebed24832797fec96098d0317c