### PR TITLE
Add batch session revocation endpoint and tests

### DIFF
--- a/api/Avancira.API.Tests/SessionsControllerTests.cs
+++ b/api/Avancira.API.Tests/SessionsControllerTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Avancira.API.Controllers;
+using Avancira.Application.Identity.Tokens;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+public class SessionsControllerTests
+{
+    [Fact]
+    public async Task RevokeSessions_UsesServiceAndReturnsNoContent()
+    {
+        var mediator = new Mock<ISender>();
+        var sessionService = new Mock<ISessionService>();
+        var controller = new SessionsController(mediator.Object, sessionService.Object);
+
+        var userId = "user-123";
+        var httpContext = new DefaultHttpContext();
+        httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, userId) }));
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        var sessions = new[] { Guid.NewGuid(), Guid.NewGuid() };
+        var result = await controller.RevokeSessions(sessions, CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+        sessionService.Verify(s => s.RevokeSessionsAsync(userId, sessions), Times.Once);
+    }
+}

--- a/api/Avancira.API/Controllers/SessionsController.cs
+++ b/api/Avancira.API/Controllers/SessionsController.cs
@@ -11,10 +11,12 @@ namespace Avancira.API.Controllers;
 public class SessionsController : BaseApiController
 {
     private readonly ISender _mediator;
+    private readonly ISessionService _sessionService;
 
-    public SessionsController(ISender mediator)
+    public SessionsController(ISender mediator, ISessionService sessionService)
     {
         _mediator = mediator;
+        _sessionService = sessionService;
     }
 
     [HttpGet]
@@ -32,6 +34,15 @@ public class SessionsController : BaseApiController
     {
         var userId = GetUserId();
         await _mediator.Send(new RevokeSessionCommand(id, userId), cancellationToken);
+        return NoContent();
+    }
+
+    [HttpPost("batch")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> RevokeSessions([FromBody] IEnumerable<Guid> sessionIds, CancellationToken cancellationToken)
+    {
+        var userId = GetUserId();
+        await _sessionService.RevokeSessionsAsync(userId, sessionIds);
         return NoContent();
     }
 }

--- a/api/Avancira.API/README.md
+++ b/api/Avancira.API/README.md
@@ -17,3 +17,9 @@ Google and Facebook authentication handlers are added only when their configurat
 
 If a provider's configuration is missing or incomplete, the application logs a warning and continues without registering that provider.
 
+## Session management
+
+- `GET /api/auth/sessions` – retrieve active sessions for the current user.
+- `DELETE /api/auth/sessions/{id}` – revoke a single session by its ID.
+- `POST /api/auth/sessions/batch` – revoke multiple sessions by providing a list of session IDs.
+

--- a/tests.http
+++ b/tests.http
@@ -17,3 +17,12 @@ Accept: application/json
 ### Get categories using the token
 GET https://localhost:9000/api/listings/-1211748162
 Accept: application/json
+
+### Revoke multiple sessions
+POST https://localhost:9000/api/auth/sessions/batch
+Content-Type: application/json
+Authorization: Bearer {{login.response.body.token}}
+
+[
+  "00000000-0000-0000-0000-000000000000"
+]


### PR DESCRIPTION
## Summary
- add POST `/api/auth/sessions/batch` to revoke multiple sessions
- document session management routes
- test batch revocation and update http examples

## Testing
- `dotnet test api/Avancira.API.Tests/Avancira.API.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae05916c4c8327a233e69551a57136