### PR TITLE
Revoke session on logout

### DIFF
--- a/Frontend.Angular/src/app/models/UserProfile.ts
+++ b/Frontend.Angular/src/app/models/UserProfile.ts
@@ -8,6 +8,7 @@ export interface UserProfile {
   ipAddress?: string;
   imageUrl?: string;
   deviceId?: string;
+  sessionId?: string;
   country?: string;
   city?: string;
   roles: string[];        // multiple roles


### PR DESCRIPTION
## Summary
- Decode session identifier from access token and revoke session with credentials before logging out
- Track session ID in `UserProfile` and Angular `AuthService`
- Add test covering session revocation and logout flow

## Testing
- `npx tsc -p tsconfig.spec.json` *(fails: Cannot find module 'angular-oauth2-oidc' and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae06dea2f483278d7a7ba3b4d75225