### PR TITLE
Remove remember me option from sign-in form

### DIFF
--- a/Frontend.Angular/src/app/pages/signin/signin.component.html
+++ b/Frontend.Angular/src/app/pages/signin/signin.component.html
@@ -39,10 +39,6 @@
                 <span class="fas fa-eye toggle-password"></span>
               </div>
             </div>
-            <div class="form-check mb-3">
-              <input type="checkbox" id="rememberMe" class="form-check-input" formControlName="rememberMe" />
-              <label class="form-check-label" for="rememberMe">Remember me</label>
-            </div>
             <div class="text-end">
               <a class="forgot-link" (click)="resetPassword()">Forgot Password ?</a>
             </div>

--- a/Frontend.Angular/src/app/pages/signin/signin.component.ts
+++ b/Frontend.Angular/src/app/pages/signin/signin.component.ts
@@ -50,7 +50,6 @@ export class SigninComponent implements OnInit {
     this.loginForm = this.fb.group({
       email: ['', [Validators.required, Validators.email]],
       password: ['', Validators.required],
-      rememberMe: [false],
     });
 
     this.route.queryParams.subscribe((params) => {


### PR DESCRIPTION
## Summary
- remove remember me checkbox from sign-in template
- drop rememberMe control from login form group

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Module not found: Error: Can't resolve 'angular-oauth2-oidc' and other build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae081a79b88327a84f231e2a778cc1