### PR TITLE
feat(auth): send cookies with OAuth token requests

### DIFF
--- a/Frontend.Angular/README.md
+++ b/Frontend.Angular/README.md
@@ -58,6 +58,15 @@ Angular CLI does not come with an end-to-end testing framework by default. You c
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
 
+## Authentication notes
+
+The application configures `OAuthService` with a custom requester so that token and refresh calls
+send cookies by default. These requests automatically skip the standard auth interceptor and set
+`withCredentials: true` via the `INCLUDE_CREDENTIALS` context token. If you need to provide your own
+OAuth implementation, ensure token requests either use a similar requester or include the
+`tokenInterceptor` from `src/app/interceptors/token.interceptor.ts` before the main auth
+interceptor.
+
 docker build -t "mirotivo/avancira-frontend:latest" -f Frontend.Angular/Dockerfile Frontend.Angular
 docker-compose build frontend-container
 docker build -t "mirotivo/avancira-frontend:latest" .

--- a/Frontend.Angular/src/app/app.config.ts
+++ b/Frontend.Angular/src/app/app.config.ts
@@ -17,6 +17,7 @@ import { ConfigService } from './services/config.service';
 import { routes } from './app.routes';
 import { authInterceptor } from './interceptors/auth.interceptor';
 import { dateInterceptorFn } from './interceptors/dateInterceptorFn';
+import { tokenInterceptor } from './interceptors/token.interceptor';
 import { OAuthModule } from 'angular-oauth2-oidc';
 
 function initConfig() {
@@ -42,7 +43,7 @@ export const appConfig: ApplicationConfig = {
 
     // HTTP client and interceptors
     provideHttpClient(
-      withInterceptors([authInterceptor, dateInterceptorFn])
+      withInterceptors([tokenInterceptor, authInterceptor, dateInterceptorFn])
     ),
 
     // Toastr configuration

--- a/Frontend.Angular/src/app/interceptors/token.interceptor.ts
+++ b/Frontend.Angular/src/app/interceptors/token.interceptor.ts
@@ -1,0 +1,15 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { INCLUDE_CREDENTIALS, SKIP_AUTH } from './auth.interceptor';
+import { environment } from '../environments/environment';
+
+/**
+ * Ensures OAuth token requests send cookies and skip auth header injection.
+ */
+export const tokenInterceptor: HttpInterceptorFn = (req, next) => {
+  const isTokenCall = req.url.startsWith(`${environment.baseApiUrl}/connect/token`);
+  if (!isTokenCall) {
+    return next(req);
+  }
+  const context = req.context.set(SKIP_AUTH, true).set(INCLUDE_CREDENTIALS, true);
+  return next(req.clone({ withCredentials: true, context }));
+};

--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -30,6 +30,14 @@ export class AuthService {
       scope: 'api offline_access',
       redirectUri: `${environment.frontendUrl}/signin-callback`,
     });
+
+    this.oauth.requester = (method, url, body, headers) =>
+      this.http.request(method, url, {
+        body,
+        headers,
+        withCredentials: true,
+        context: new HttpContext().set(SKIP_AUTH, true).set(INCLUDE_CREDENTIALS, true),
+      });
   }
 
   init(): Promise<void> {


### PR DESCRIPTION
## Summary
- configure OAuthService to use a custom requester that sends token and refresh calls with credentials and skips auth headers
- add token interceptor so OAuth token requests automatically include credentials and bypass auth injection
- document authentication module usage for token requests

## Testing
- `npm test -- --watch=false` *(fails: Module not found: Can't resolve 'angular-oauth2-oidc')*

------
https://chatgpt.com/codex/tasks/task_e_68ae08ecf608832781dc080ed086dc58