### PR TITLE
Remove remember-me flag from token generation

### DIFF
--- a/admin/Infrastructure/Api/ApiClient.cs
+++ b/admin/Infrastructure/Api/ApiClient.cs
@@ -7134,9 +7134,6 @@ namespace Avancira.Admin.Infrastructure.Api
         [System.Text.Json.Serialization.JsonPropertyName("password")]
         public string? Password { get; set; } = default!;
 
-        [System.Text.Json.Serialization.JsonPropertyName("rememberMe")]
-        public bool RememberMe { get; set; } = default!;
-
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.3.0.0 (NJsonSchema v11.2.0.0 (Newtonsoft.Json v13.0.0.0))")]

--- a/api/Avancira.Application/Identity/Tokens/Dtos/TokenGenerationDto.cs
+++ b/api/Avancira.Application/Identity/Tokens/Dtos/TokenGenerationDto.cs
@@ -1,2 +1,4 @@
-﻿namespace Avancira.Application.Identity.Tokens.Dtos;
-public record TokenGenerationDto(string Email, string Password, bool RememberMe);
+namespace Avancira.Application.Identity.Tokens.Dtos;
+
+public record TokenGenerationDto(string Email, string Password);
+

--- a/api/Avancira.Application/Identity/Tokens/Validators/GenerateTokenValidator.cs
+++ b/api/Avancira.Application/Identity/Tokens/Validators/GenerateTokenValidator.cs
@@ -9,7 +9,5 @@ public class GenerateTokenValidator : AbstractValidator<TokenGenerationDto>
         RuleFor(p => p.Email).Cascade(CascadeMode.Stop).NotEmpty().EmailAddress();
 
         RuleFor(p => p.Password).Cascade(CascadeMode.Stop).NotEmpty();
-
-        RuleFor(p => p.RememberMe).NotNull();
     }
 }


### PR DESCRIPTION
## Summary
- drop `RememberMe` from token generation DTO and validation
- regenerate API client to match updated DTO

## Testing
- ⚠️ `dotnet test api/Avancira.API.Tests` *(dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae094ff1f083278753b04b5a616094