### PR TITLE
feat: add refresh token endpoint

### DIFF
--- a/api/Avancira.API.Tests/AuthControllerTests.cs
+++ b/api/Avancira.API.Tests/AuthControllerTests.cs
@@ -6,6 +6,7 @@ using Avancira.Application.Auth;
 using Avancira.Application.Auth.Dtos;
 using Avancira.Application.Identity;
 using Avancira.Application.Identity.Tokens.Dtos;
+using Avancira.Application.Identity.Tokens;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -21,8 +22,9 @@ public class AuthControllerTests
         var externalAuth = new Mock<IExternalAuthService>();
         var externalUser = new Mock<IExternalUserService>();
         var authService = new Mock<IAuthenticationService>();
+        var sessionService = new Mock<ISessionService>();
 
-        var controller = new AuthController(authService.Object, externalAuth.Object, externalUser.Object);
+        var controller = new AuthController(authService.Object, externalAuth.Object, externalUser.Object, sessionService.Object);
         var httpContext = new DefaultHttpContext();
         controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
 
@@ -53,8 +55,9 @@ public class AuthControllerTests
         var externalAuth = new Mock<IExternalAuthService>();
         var externalUser = new Mock<IExternalUserService>();
         var authService = new Mock<IAuthenticationService>();
+        var sessionService = new Mock<ISessionService>();
 
-        var controller = new AuthController(authService.Object, externalAuth.Object, externalUser.Object);
+        var controller = new AuthController(authService.Object, externalAuth.Object, externalUser.Object, sessionService.Object);
 
         externalAuth.Setup(s => s.ValidateTokenAsync(SocialProvider.Google, "bad"))
             .ReturnsAsync(ExternalAuthResult.Fail(ExternalAuthErrorType.InvalidToken, "invalid"));
@@ -72,8 +75,9 @@ public class AuthControllerTests
         var externalAuth = new Mock<IExternalAuthService>();
         var externalUser = new Mock<IExternalUserService>();
         var authService = new Mock<IAuthenticationService>();
+        var sessionService = new Mock<ISessionService>();
 
-        var controller = new AuthController(authService.Object, externalAuth.Object, externalUser.Object);
+        var controller = new AuthController(authService.Object, externalAuth.Object, externalUser.Object, sessionService.Object);
 
         var principal = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Email, "user@example.com") }, "Google"));
         var loginInfo = new ExternalLoginInfo(principal, "Google", "123", "Google");

--- a/api/Avancira.Application/Identity/IAuthenticationService.cs
+++ b/api/Avancira.Application/Identity/IAuthenticationService.cs
@@ -1,8 +1,11 @@
+using Avancira.Application.Identity.Tokens.Dtos;
+
 namespace Avancira.Application.Identity;
 
 public interface IAuthenticationService
 {
     Task<TokenPair> ExchangeCodeAsync(string code, string codeVerifier, string redirectUri);
     Task<TokenPair> GenerateTokenAsync(string userId);
+    Task<TokenPair> RefreshTokenAsync(string refreshToken);
 }
 

--- a/api/Avancira.Application/Identity/Tokens/ISessionService.cs
+++ b/api/Avancira.Application/Identity/Tokens/ISessionService.cs
@@ -11,4 +11,6 @@ public interface ISessionService
     Task RevokeSessionAsync(string userId, Guid sessionId);
     Task RevokeSessionsAsync(string userId, IEnumerable<Guid> sessionIds);
     Task<bool> ValidateSessionAsync(string userId, Guid sessionId);
+    Task<(string UserId, Guid RefreshTokenId)?> GetRefreshTokenInfoAsync(string tokenHash);
+    Task RotateRefreshTokenAsync(Guid refreshTokenId, string newRefreshTokenHash, DateTime newExpiry);
 }


### PR DESCRIPTION
## Summary
- add endpoint to refresh auth tokens and rotate refresh cookie
- extend authentication and session services for refresh token validation and rotation
- update tests for new controller dependencies

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae19140ec88327ac9d622b0a969d3d