### PR TITLE
Conditionally set refresh token cookie secure flag

### DIFF
--- a/api/Avancira.API.Tests/BaseApiControllerTests.cs
+++ b/api/Avancira.API.Tests/BaseApiControllerTests.cs
@@ -4,6 +4,9 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using Xunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
 
 public class BaseApiControllerTests
 {
@@ -19,7 +22,15 @@ public class BaseApiControllerTests
     public void SetRefreshTokenCookie_WithExpiry_SetsCookieWithOptions()
     {
         var controller = new TestController();
-        var httpContext = new DefaultHttpContext();
+        var envMock = new Mock<IHostEnvironment>();
+        envMock.SetupGet(e => e.EnvironmentName).Returns(Environments.Production);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(envMock.Object);
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider()
+        };
         controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
 
         var expires = DateTime.UtcNow.AddDays(1);
@@ -39,7 +50,15 @@ public class BaseApiControllerTests
     public void SetRefreshTokenCookie_WithoutExpiry_SetsSessionCookie()
     {
         var controller = new TestController();
-        var httpContext = new DefaultHttpContext();
+        var envMock = new Mock<IHostEnvironment>();
+        envMock.SetupGet(e => e.EnvironmentName).Returns(Environments.Production);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(envMock.Object);
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider()
+        };
         controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
 
         controller.InvokeSetRefreshTokenCookie("token456", null);
@@ -51,5 +70,27 @@ public class BaseApiControllerTests
         setCookie.Should().Contain("samesite=none");
         setCookie.Should().Contain("secure");
         setCookie.Should().NotContain("expires=");
+    }
+
+    [Fact]
+    public void SetRefreshTokenCookie_InDevelopment_DoesNotSetSecure()
+    {
+        var controller = new TestController();
+        var envMock = new Mock<IHostEnvironment>();
+        envMock.SetupGet(e => e.EnvironmentName).Returns(Environments.Development);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(envMock.Object);
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider()
+        };
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        controller.InvokeSetRefreshTokenCookie("token789", null);
+
+        var setCookie = httpContext.Response.Headers["Set-Cookie"].ToString().ToLowerInvariant();
+        setCookie.Should().Contain("refreshtoken=token789");
+        setCookie.Should().NotContain("secure");
     }
 }

--- a/api/Avancira.API/Controllers/BaseApiController.cs
+++ b/api/Avancira.API/Controllers/BaseApiController.cs
@@ -2,6 +2,8 @@
 using Microsoft.AspNetCore.Http;
 using System.Security.Claims;
 using System;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Avancira.API.Controllers;
 
@@ -65,7 +67,6 @@ public abstract class BaseApiController : ControllerBase
         var cookieOptions = new CookieOptions
         {
             HttpOnly = true,
-            Secure = true,
             SameSite = SameSiteMode.None,
             Path = "/api/auth"
         };
@@ -74,6 +75,8 @@ public abstract class BaseApiController : ControllerBase
         {
             cookieOptions.Expires = expires.Value;
         }
+        var env = HttpContext.RequestServices.GetRequiredService<IHostEnvironment>();
+        cookieOptions.Secure = !env.IsDevelopment();
 
         Response.Cookies.Append("refreshToken", refreshToken, cookieOptions);
     }


### PR DESCRIPTION
## Summary
- set refresh token cookie `Secure` flag only outside development environments
- update base API controller tests to inject `IHostEnvironment` and cover development scenario

## Testing
- ⚠️ `dotnet test` *(dotnet not installed)*
- ⚠️ `apt-get update` *(403 fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1b72bd00832789f70974a7b43352