### PR TITLE
Refactor AuthService login flow

### DIFF
--- a/Frontend.Angular/src/app/pages/signin/signin.component.spec.ts
+++ b/Frontend.Angular/src/app/pages/signin/signin.component.spec.ts
@@ -42,8 +42,8 @@ describe('LoginComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should initiate Google login flow', async () => {
-    authService.startLogin.and.returnValue(Promise.resolve());
+  it('should initiate Google login flow', () => {
+    authService.startLogin.and.stub();
     component.returnUrl = '/home';
 
     component.authenticate(SocialProvider.Google);
@@ -51,8 +51,8 @@ describe('LoginComponent', () => {
     expect(authService.startLogin).toHaveBeenCalledWith('/home', SocialProvider.Google);
   });
 
-  it('should initiate Facebook login flow', async () => {
-    authService.startLogin.and.returnValue(Promise.resolve());
+  it('should initiate Facebook login flow', () => {
+    authService.startLogin.and.stub();
     component.returnUrl = '/home';
 
     component.authenticate(SocialProvider.Facebook);

--- a/Frontend.Angular/src/app/pages/signin/signin.component.ts
+++ b/Frontend.Angular/src/app/pages/signin/signin.component.ts
@@ -72,11 +72,11 @@ export class SigninComponent implements OnInit {
 
   /** Regular login */
   onLogin(): void {
-    void this.authService.startLogin(this.returnUrl);
+    this.authService.startLogin(this.returnUrl);
   }
 
   authenticate(provider: SocialProvider): void {
-    void this.authService.startLogin(this.returnUrl, provider);
+    this.authService.startLogin(this.returnUrl, provider);
   }
 
   /** Password reset prompt */

--- a/Frontend.Angular/src/app/pages/signup/signup.component.spec.ts
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.spec.ts
@@ -43,7 +43,7 @@ describe('SignupComponent', () => {
   });
 
   it('should initiate Google signup flow', () => {
-    authService.startLogin.and.returnValue(Promise.resolve());
+    authService.startLogin.and.stub();
     component.returnUrl = '/home';
 
     component.authenticate(SocialProvider.Google);
@@ -52,7 +52,7 @@ describe('SignupComponent', () => {
   });
 
   it('should initiate Facebook signup flow', () => {
-    authService.startLogin.and.returnValue(Promise.resolve());
+    authService.startLogin.and.stub();
     component.returnUrl = '/home';
 
     component.authenticate(SocialProvider.Facebook);

--- a/Frontend.Angular/src/app/pages/signup/signup.component.ts
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.ts
@@ -151,7 +151,7 @@ export class SignupComponent implements OnInit, OnDestroy {
   }
 
   authenticate(provider: SocialProvider): void {
-    void this.authService.startLogin(this.returnUrl, provider);
+    this.authService.startLogin(this.returnUrl, provider);
   }
 
   ngOnDestroy(): void {

--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -83,9 +83,9 @@ export class AuthService {
     return this.waitForRefresh().pipe(map(() => this.oauth.getAccessToken() as string));
   }
 
-  startLogin(returnUrl = this.router.url, provider?: SocialProvider): Promise<void> {
+  startLogin(returnUrl = this.router.url, provider?: SocialProvider): void {
     this.oauth.customQueryParams = provider ? { provider } : {};
-    return Promise.resolve(this.oauth.initCodeFlow(returnUrl));
+    this.oauth.initCodeFlow(returnUrl);
   }
 
   logout(navigate = true): void {


### PR DESCRIPTION
## Summary
- make `AuthService.startLogin` synchronous and remove `Promise.resolve`
- update Signin/Signup components and specs to treat `startLogin` as synchronous

## Testing
- `npm test -- --watch=false` *(fails: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1b976b9c8327aafd528caf3c292f