### PR TITLE
Use AuthService for auth checks

### DIFF
--- a/Frontend.Angular/src/app/components/payment-alt-options/payment-alt-options.component.ts
+++ b/Frontend.Angular/src/app/components/payment-alt-options/payment-alt-options.component.ts
@@ -6,6 +6,7 @@ import { ConfigService } from '../../services/config.service';
 import { ListingService } from '../../services/listing.service';
 import { PaymentService } from '../../services/payment.service';
 import { SubscriptionService } from '../../services/subscription.service';
+import { AuthService } from '../../services/auth.service';
 import { ConfigKey } from '../../models/config-key';
 
 
@@ -18,7 +19,6 @@ import { ConfigKey } from '../../models/config-key';
 })
 export class PaymentAltOptionsComponent implements OnInit {
   listingId!: string;
-  isLoggedIn = false; // Check if the user is logged in
   paymentMethod: 'card' | 'paypal' = 'paypal';
   subscription = {
     title: 'Student Pass',
@@ -37,12 +37,13 @@ export class PaymentAltOptionsComponent implements OnInit {
     private listingService: ListingService,
     private paymentService: PaymentService,
     private subscriptionService: SubscriptionService,
-    private configService: ConfigService
+    private configService: ConfigService,
+    private authService: AuthService,
   ) { }
 
 
   ngOnInit(): void {
-    this.isLoggedIn = !!localStorage.getItem('token'); // Check if token exists
+    this.authService.isAuthenticated();
     this.stripePromise = loadStripe(this.configService.get(ConfigKey.StripePublishableKey));
 
     this.paymentService.loadPayPalScript().then(() => {

--- a/Frontend.Angular/src/app/pages/payment/payment.component.html
+++ b/Frontend.Angular/src/app/pages/payment/payment.component.html
@@ -27,7 +27,7 @@
                     </div>
                 </div>
 
-                <div class="card" *ngIf="isLoggedIn; else notLoggedIn">
+                <div class="card" *ngIf="authService.isAuthenticated(); else notLoggedIn">
                     <div class="card-body">
                         <!-- Subscription Form -->
                         <div class="payment-widget">

--- a/Frontend.Angular/src/app/pages/payment/payment.component.ts
+++ b/Frontend.Angular/src/app/pages/payment/payment.component.ts
@@ -7,6 +7,7 @@ import { PaymentMethodComponent } from '../../components/payment-method/payment-
 
 import { AlertService } from '../../services/alert.service';
 import { SubscriptionService } from '../../services/subscription.service';
+import { AuthService } from '../../services/auth.service';
 
 import { Card } from '../../models/card';
 import { SubscriptionBillingFrequency } from '../../models/enums/subscription-billing-frequency';
@@ -25,21 +26,19 @@ export class PaymentComponent implements OnInit {
   CardType: UserCardType = UserCardType.Paying;
   referrer: string | null = null;
   loading = true;
-  isLoggedIn = false;
   selectedCard: Card | null = null;
 
   constructor(
     private alertService: AlertService,
     private route: ActivatedRoute,
     private router: Router,
-    private subscriptionService: SubscriptionService
+    private subscriptionService: SubscriptionService,
+    public authService: AuthService,
   ) {
     this.handlePayment = this.handlePayment.bind(this);
   }
 
   ngOnInit(): void {
-    this.isLoggedIn = !!localStorage.getItem('token');
-
     this.route.queryParams.subscribe((params) => {
       this.referrer = params['referrer'] || '/';
     });

--- a/Frontend.Angular/src/app/pages/premium-subscription/premium-subscription.component.html
+++ b/Frontend.Angular/src/app/pages/premium-subscription/premium-subscription.component.html
@@ -16,7 +16,7 @@
       </ul>
     </div>
 
-    <div *ngIf="isLoggedIn; else notLoggedIn">
+    <div *ngIf="authService.isAuthenticated(); else notLoggedIn">
       <app-manage-cards *ngIf="!savedCardsAvailable" [cardPurpose]="CardType" (cardSelected)="onCardSelected($event)">
       </app-manage-cards>
       <button class="pay-button" [disabled]="!selectedCard" (click)="payWithSelectedCard()">

--- a/Frontend.Angular/src/app/pages/premium-subscription/premium-subscription.component.ts
+++ b/Frontend.Angular/src/app/pages/premium-subscription/premium-subscription.component.ts
@@ -10,6 +10,7 @@ import { AlertService } from '../../services/alert.service';
 import { ConfigService } from '../../services/config.service';
 import { PaymentService } from '../../services/payment.service';
 import { SubscriptionService } from '../../services/subscription.service';
+import { AuthService } from '../../services/auth.service';
 import { ConfigKey } from '../../models/config-key';
 
 import { Card } from '../../models/card';
@@ -40,7 +41,6 @@ export class PremiumSubscriptionComponent implements OnInit {
   };
 
   CardType: UserCardType = UserCardType.Paying;
-  isLoggedIn = false;
   paymentMethod: 'card' | 'paypal' = 'paypal';
   stripePromise: Promise<any> | null = null; 
   savedCards: Card[] = []; // Add saved cards property
@@ -52,11 +52,12 @@ export class PremiumSubscriptionComponent implements OnInit {
     private router: Router,
     private paymentService: PaymentService,
     private subscriptionService: SubscriptionService,
-    private configService: ConfigService
+    private configService: ConfigService,
+    public authService: AuthService,
   ) {}
 
   ngOnInit(): void {
-    this.isLoggedIn = !!localStorage.getItem('token');
+    this.authService.isAuthenticated();
     this.stripePromise = loadStripe(this.configService.get(ConfigKey.StripePublishableKey));
   }
 


### PR DESCRIPTION
## Summary
- Inject `AuthService` into payment-related components and remove direct `localStorage` token checks.
- Drive login-dependent templates off `authService.isAuthenticated()` instead of internal flags.

## Testing
- `CI=true npm test -- --watch=false --progress=false` *(fails: export and module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1d5f9d8c8327a4d005952f994eba