### PR TITLE
Handle missing user without exceptions

### DIFF
--- a/api/Avancira.API/Controllers/BaseApiController.cs
+++ b/api/Avancira.API/Controllers/BaseApiController.cs
@@ -13,19 +13,14 @@ public abstract class BaseApiController : ControllerBase
     /// <summary>
     /// Gets the current user's ID from JWT claims
     /// </summary>
-    /// <returns>User ID if authenticated, otherwise throws UnauthorizedAccessException</returns>
-    protected string GetUserId()
+    /// <returns>User ID if authenticated, otherwise null</returns>
+    protected string? GetUserId()
     {
-        var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value 
-                    ?? User.FindFirst("sub")?.Value 
+        var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                    ?? User.FindFirst("sub")?.Value
                     ?? User.FindFirst("userId")?.Value;
-        
-        if (string.IsNullOrEmpty(userId))
-        {
-            throw new UnauthorizedAccessException("User ID not found in token claims");
-        }
-        
-        return userId;
+
+        return string.IsNullOrEmpty(userId) ? null : userId;
     }
 
     /// <summary>

--- a/api/Avancira.API/Controllers/ChatsController.cs
+++ b/api/Avancira.API/Controllers/ChatsController.cs
@@ -31,6 +31,10 @@ public class ChatsController : BaseApiController
     public IActionResult GetUserChats()
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var chats = _chatService.GetUserChats(userId);
         return Ok(chats);
     }
@@ -40,6 +44,10 @@ public class ChatsController : BaseApiController
     public IActionResult GetChatById(Guid id)
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var chat = _chatService.GetChat(id, userId);
         if (chat.Id == Guid.Empty)
         {
@@ -69,6 +77,10 @@ public class ChatsController : BaseApiController
 
         // Check if a chat already exists
         var senderId = GetUserId();
+        if (senderId is null)
+        {
+            return Unauthorized();
+        }
 
         if (!await _chatService.SendMessageAsync(messageDto, senderId))
         {

--- a/api/Avancira.API/Controllers/EvaluationsController.cs
+++ b/api/Avancira.API/Controllers/EvaluationsController.cs
@@ -28,6 +28,10 @@ public class EvaluationsController : BaseApiController
     public async Task<IActionResult> LeaveReviewAsync([FromBody] ReviewDto reviewDto)
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
 
         // Validate the input
         if (reviewDto == null)
@@ -57,6 +61,10 @@ public class EvaluationsController : BaseApiController
     public async Task<IActionResult> SubmitRecommendation([FromBody] ReviewDto dto)
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
 
         if (string.IsNullOrEmpty(dto.RevieweeId) || string.IsNullOrEmpty(dto.Feedback))
             return BadRequest("Invalid data.");
@@ -79,6 +87,10 @@ public class EvaluationsController : BaseApiController
     public async Task<IActionResult> GetEvaluationsAsync()
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
 
         // Identify pending reviews based on the user's role
         var pendingReviews = await _evaluationService.GetPendingReviewsAsync(userId);

--- a/api/Avancira.API/Controllers/LessonsController.cs
+++ b/api/Avancira.API/Controllers/LessonsController.cs
@@ -26,6 +26,10 @@ public class LessonsController : BaseApiController
     public async Task<IActionResult> ProposeLessonAsync([FromBody] LessonDto lessonDto)
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var result = await _lessonService.ProposeLessonAsync(lessonDto, userId);
         return Ok(new { Message = "Lesson proposed successfully.", Lesson = result });
     }
@@ -36,6 +40,10 @@ public class LessonsController : BaseApiController
     public async Task<IActionResult> GetLessonsAsync(string contactId, Guid listingId, [FromQuery] int page = 1, [FromQuery] int pageSize = 10)
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var lessons = await _lessonService.GetLessonsAsync(contactId, userId, listingId, page, pageSize);
         return Ok(new { Lessons = lessons });
     }
@@ -50,6 +58,10 @@ public class LessonsController : BaseApiController
         }
 
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var lessons = await _lessonService.GetAllLessonsAsync(userId, filters);
         return Ok(new { Lessons = lessons });
     }
@@ -60,6 +72,10 @@ public class LessonsController : BaseApiController
     public async Task<IActionResult> RespondToPropositionAsync(Guid lessonId, [FromBody] bool accept)
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         LessonDto updatedLesson;
         try
         {
@@ -89,6 +105,10 @@ public class LessonsController : BaseApiController
         try
         {
             var userId = GetUserId();
+            if (userId is null)
+            {
+                return Unauthorized();
+            }
             var canceledLesson = await _lessonService.UpdateLessonStatusAsync(lessonId, false, userId);
 
             return Ok(new

--- a/api/Avancira.API/Controllers/ListingsController.cs
+++ b/api/Avancira.API/Controllers/ListingsController.cs
@@ -30,6 +30,10 @@ public class ListingsController : BaseApiController
         pageSize = Math.Clamp(pageSize, 1, 100);
 
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var result = await _listingService.GetTutorListingsAsync(userId, page, pageSize, ct);
 
         return Ok(new
@@ -55,6 +59,10 @@ public class ListingsController : BaseApiController
         }
 
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var listing = await _listingService.CreateListingAsync(model, userId, ct);
 
         return CreatedAtAction(nameof(GetListingById), new { id = listing.Id }, new
@@ -73,6 +81,10 @@ public class ListingsController : BaseApiController
         model.Id = id;
 
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var updatedListing = await _listingService.UpdateListingAsync(model, userId, ct);
 
         return Ok(new
@@ -114,6 +126,10 @@ public class ListingsController : BaseApiController
         pageSize = Math.Clamp(pageSize, 1, 100);
 
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var listings = await _listingService.GetTutorListingsAsync(userId, page, pageSize, ct);
         return Ok(listings);
     }
@@ -134,6 +150,10 @@ public class ListingsController : BaseApiController
     public async Task<IActionResult> ToggleVisibility(Guid id, CancellationToken ct = default)
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var success = await _listingService.ToggleListingVisibilityAsync(id, userId, ct);
         if (!success)
             return NotFound($"Listing with ID {id} not found or unauthorized.");
@@ -149,6 +169,10 @@ public class ListingsController : BaseApiController
             return BadRequest("Title is required.");
 
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var success = await _listingService.ModifyListingTitleAsync(id, userId, dto.Title.Trim(), ct);
         if (!success)
             return NotFound("Listing not found or unauthorized.");
@@ -180,6 +204,10 @@ public class ListingsController : BaseApiController
             return BadRequest("At least one location is required.");
 
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var success = await _listingService.ModifyListingLocationsAsync(id, userId, locations, ct);
         if (!success)
             return BadRequest("Failed to update locations.");
@@ -195,6 +223,10 @@ public class ListingsController : BaseApiController
             return BadRequest("Payload is required.");
 
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var success = await _listingService.ModifyListingDescriptionAsync(id, userId, dto.AboutLesson, dto.AboutYou, ct);
         if (!success)
             return NotFound("Listing not found or unauthorized.");
@@ -210,6 +242,10 @@ public class ListingsController : BaseApiController
             return BadRequest("Payload is required.");
 
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var success = await _listingService.ModifyListingRatesAsync(id, userId, dto, ct);
         if (!success)
             return NotFound("Listing not found or unauthorized.");
@@ -225,6 +261,10 @@ public class ListingsController : BaseApiController
             return BadRequest("Valid category is required.");
 
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var success = await _listingService.ModifyListingCategoryAsync(id, userId, dto.LessonCategoryId, ct);
         if (!success)
             return NotFound("Listing not found or unauthorized.");
@@ -241,6 +281,10 @@ public class ListingsController : BaseApiController
             return NotFound($"Listing with ID {id} not found.");
 
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var success = await _listingService.DeleteListingAsync(id, userId, ct);
         if (!success)
             return BadRequest("Failed to delete listing.");

--- a/api/Avancira.API/Controllers/PaymentsController.cs
+++ b/api/Avancira.API/Controllers/PaymentsController.cs
@@ -58,6 +58,10 @@ public class PaymentsController : BaseApiController
         try
         {
             var userId = GetUserId();
+            if (userId is null)
+            {
+                return Unauthorized();
+            }
             var userPaymentGateway = "Stripe"; // TODO: Get from user service
             var payoutId = await _paymentService.CreatePayoutAsync(userId, request.Amount, request.Currency.ToLower(), userPaymentGateway);
 
@@ -104,6 +108,10 @@ public class PaymentsController : BaseApiController
     public async Task<IActionResult> HistoryAsync()
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var paymentHistory = await _paymentService.GetPaymentHistoryAsync(userId);
         return Ok(paymentHistory);
     }
@@ -114,6 +122,10 @@ public class PaymentsController : BaseApiController
     public async Task<IActionResult> SaveCard([FromBody] SaveCardDto request)
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         await _stripeCardService.AddUserCardAsync(userId, request);
         return Ok(new { success = true, message = "Card saved successfully." });
     }
@@ -123,6 +135,10 @@ public class PaymentsController : BaseApiController
     public async Task<IActionResult> RemoveCard(int Id)
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         await _stripeCardService.RemoveUserCardAsync(userId, Id);
         return Ok(new { success = true, message = "Card removed successfully." });
     }
@@ -132,6 +148,10 @@ public class PaymentsController : BaseApiController
     public async Task<IActionResult> GetSavedCardsAsync()
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var cards = await _stripeCardService.GetUserCardsAsync(userId);
         return Ok(cards);
     }
@@ -143,6 +163,10 @@ public class PaymentsController : BaseApiController
     public async Task<IActionResult> CreateStripeAccount()
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var url = await _stripeAccountService.ConnectStripeAccountAsync(userId);
         return Ok(new { url });
     }
@@ -154,6 +178,10 @@ public class PaymentsController : BaseApiController
     public async Task<IActionResult> CreatePayPalAccount([FromBody] PayPalAuthRequest request)
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         try
         {
             var success = await _payPalAccountService.ConnectPayPalAccountAsync(userId, request.AuthCode);

--- a/api/Avancira.API/Controllers/SessionsController.cs
+++ b/api/Avancira.API/Controllers/SessionsController.cs
@@ -24,6 +24,10 @@ public class SessionsController : BaseApiController
     public async Task<IActionResult> GetSessions(CancellationToken cancellationToken)
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var sessions = await _mediator.Send(new GetSessionsQuery(userId), cancellationToken);
         return Ok(sessions);
     }
@@ -33,6 +37,10 @@ public class SessionsController : BaseApiController
     public async Task<IActionResult> RevokeSession(Guid id, CancellationToken cancellationToken)
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         await _mediator.Send(new RevokeSessionCommand(id, userId), cancellationToken);
         return NoContent();
     }
@@ -42,6 +50,10 @@ public class SessionsController : BaseApiController
     public async Task<IActionResult> RevokeSessions([FromBody] IEnumerable<Guid> sessionIds, CancellationToken cancellationToken)
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         await _sessionService.RevokeSessionsAsync(userId, sessionIds);
         return NoContent();
     }

--- a/api/Avancira.API/Controllers/SubscriptionsController.cs
+++ b/api/Avancira.API/Controllers/SubscriptionsController.cs
@@ -28,6 +28,10 @@ public class SubscriptionsController : BaseApiController
         try
         {
             var userId = GetUserId();
+            if (userId is null)
+            {
+                return Unauthorized();
+            }
             var (subscriptionId, transactionId) = await _subscriptionService.CreateSubscriptionAsync(request, userId);
             return Ok(new { SubscriptionId = subscriptionId, TransactionId = transactionId });
         }
@@ -47,6 +51,10 @@ public class SubscriptionsController : BaseApiController
     public async Task<IActionResult> CheckActiveSubscription()
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var hasActiveSubscription = await _subscriptionService.HasActiveSubscriptionAsync(userId);
         return Ok(new { IsActive = hasActiveSubscription });
     }
@@ -56,6 +64,10 @@ public class SubscriptionsController : BaseApiController
     public async Task<IActionResult> GetUserSubscriptions([FromQuery] int page = 1, [FromQuery] int pageSize = 10)
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var subscriptions = await _subscriptionService.ListUserSubscriptionsAsync(userId, page, pageSize);
 
         if (subscriptions == null || subscriptions.TotalResults == 0)
@@ -88,6 +100,10 @@ public class SubscriptionsController : BaseApiController
     public async Task<IActionResult> GetSubscriptionDetails()
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var details = await _subscriptionService.FetchSubscriptionDetailsAsync(userId);
         if (details == null) return NotFound(new { Message = "No active subscription found." });
 
@@ -100,6 +116,10 @@ public class SubscriptionsController : BaseApiController
     public async Task<IActionResult> ChangeBillingFrequency([FromBody] ChangeFrequencyRequestDto request)
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var success = await _subscriptionService.ChangeBillingFrequencyAsync(userId, request.NewFrequency);
 
         if (!success)
@@ -114,6 +134,10 @@ public class SubscriptionsController : BaseApiController
     public async Task<IActionResult> CancelSubscription()
     {
         var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var success = await _subscriptionService.CancelSubscriptionAsync(userId);
 
         if (!success)

--- a/api/Avancira.API/Controllers/UsersController.cs
+++ b/api/Avancira.API/Controllers/UsersController.cs
@@ -52,7 +52,10 @@ public class UsersController : BaseApiController
     public async Task<IActionResult> GetUserProfile(CancellationToken cancellationToken)
     {
         var userId = User.GetUserId();
-
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         var userProfile = await _userService.GetAsync(userId, cancellationToken);
         return Ok(userProfile);
     }
@@ -63,12 +66,10 @@ public class UsersController : BaseApiController
     public async Task<IActionResult> GetUserPermissionsAsync(CancellationToken cancellationToken)
     {
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-
         if (string.IsNullOrWhiteSpace(userId))
         {
-            throw new UnauthorizedException();
+            return Unauthorized();
         }
-
         var permissions = await _userService.GetPermissionsAsync(userId, cancellationToken);
         return Ok(permissions);
     }
@@ -169,7 +170,10 @@ public class UsersController : BaseApiController
     public async Task<IActionResult> ChangePassword([FromBody] ChangePasswordDto command, CancellationToken cancellationToken)
     {
         var userId = User.GetUserId();
-
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         await _userService.ChangePasswordAsync(command, userId);
         return Ok("Password changed successfully.");
     }
@@ -204,7 +208,10 @@ public class UsersController : BaseApiController
     public async Task<IActionResult> UpdateUserProfile([FromForm] UpdateUserDto request)
     {
         var userId = User.GetUserId();
-
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
         await _userService.UpdateAsync(request, userId);
         return Ok("User profile updated successfully.");
     }
@@ -247,10 +254,10 @@ public class UsersController : BaseApiController
     public async Task<IActionResult> GetCurrentUser(CancellationToken cancellationToken)
     {
         var userId = User.GetUserId();
-
         if (string.IsNullOrWhiteSpace(userId))
-            throw new UnauthorizedException();
-
+        {
+            return Unauthorized();
+        }
         var user = await _userService.GetAsync(userId, cancellationToken);
         return Ok(user);
     }
@@ -261,13 +268,15 @@ public class UsersController : BaseApiController
     public async Task<IActionResult> GetProfileImage(CancellationToken cancellationToken)
     {
         var currentUserId = User.GetUserId();
-
         if (string.IsNullOrWhiteSpace(currentUserId))
-            throw new UnauthorizedException();
-
+        {
+            return Unauthorized();
+        }
         var user = await _userService.GetAsync(currentUserId, cancellationToken);
         if (user == null)
-            throw new UnauthorizedException();
+        {
+            return Unauthorized();
+        }
 
         var imagePath = Path.Combine(Directory.GetCurrentDirectory(), "UserImages", $"{currentUserId}.jpg");
 

--- a/api/Avancira.API/Controllers/WalletsController.cs
+++ b/api/Avancira.API/Controllers/WalletsController.cs
@@ -45,6 +45,10 @@ public class WalletsController : BaseApiController
         try
         {
             var userId = GetUserId();
+            if (userId is null)
+            {
+                return Unauthorized();
+            }
             var result = await _walletService.GetWalletBalanceAsync(userId);
             return Ok(new { Balance = result.Balance, LastUpdated = result.LastUpdated });
         }


### PR DESCRIPTION
## Summary
- Return `null` instead of throwing from `BaseApiController.GetUserId`
- Have API actions check for missing user IDs and return `Unauthorized`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae21161680832792e9386fda637ecd