### PR TITLE
Handle scalar role claims in auth decode

### DIFF
--- a/Frontend.Angular/src/app/services/auth.service.spec.ts
+++ b/Frontend.Angular/src/app/services/auth.service.spec.ts
@@ -22,7 +22,8 @@ describe('AuthService', () => {
       'getAccessToken',
       'refreshToken',
       'initCodeFlow',
-      'logOut'
+      'logOut',
+      'getIdentityClaims'
     ]);
 
     routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'createUrlTree']);
@@ -80,4 +81,32 @@ describe('AuthService', () => {
     expect(results).toEqual(['new-token', 'new-token']);
     expect(oauthSpy.refreshToken).toHaveBeenCalledTimes(1);
   }));
+
+  describe('decode', () => {
+    it('normalizes single role and permission claims to arrays', () => {
+      oauthSpy.getIdentityClaims.and.returnValue({
+        sub: '1',
+        role: 'admin',
+        permission: 'read'
+      });
+
+      const profile = service.decode();
+
+      expect(profile?.roles).toEqual(['admin']);
+      expect(profile?.permissions).toEqual(['read']);
+    });
+
+    it('returns role and permission claims as arrays when already arrays', () => {
+      oauthSpy.getIdentityClaims.and.returnValue({
+        sub: '1',
+        role: ['admin', 'user'],
+        permission: ['read', 'write']
+      });
+
+      const profile = service.decode();
+
+      expect(profile?.roles).toEqual(['admin', 'user']);
+      expect(profile?.permissions).toEqual(['read', 'write']);
+    });
+  });
 });

--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -124,6 +124,16 @@ export class AuthService {
     );
   }
 
+  private normalizeClaim(value: unknown): string[] {
+    if (Array.isArray(value)) {
+      return value as string[];
+    }
+    if (typeof value === 'string') {
+      return [value];
+    }
+    return [];
+  }
+
   decode(): UserProfile | null {
     const claims = this.oauth.getIdentityClaims() as Record<string, unknown> | null;
     if (!claims || typeof claims !== 'object' || !('sub' in claims)) {
@@ -144,8 +154,8 @@ export class AuthService {
         sessionId: (claims['sid'] ?? claims['session_id']) as string,
         country: claims['country'] as string,
         city: claims['city'] as string,
-        roles: (claims['role'] ?? []) as string[],
-        permissions: (claims['permission'] ?? []) as string[],
+        roles: this.normalizeClaim(claims['role']),
+        permissions: this.normalizeClaim(claims['permission']),
         exp: claims['exp'] as number,
       };
       return profile;


### PR DESCRIPTION
## Summary
- Normalize role and permission claims to arrays in `auth.service` using new `normalizeClaim` helper
- Add unit tests for decoding single string and array role/permission claims

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --no-progress` *(fails: export/module not found errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ae21317a2c8327966822d86b1fd926