### PR TITLE
Avoid logging authentication tokens

### DIFF
--- a/api/Avancira.Infrastructure/Auth/Jwt/ConfigureJwtBearerOptions.cs
+++ b/api/Avancira.Infrastructure/Auth/Jwt/ConfigureJwtBearerOptions.cs
@@ -69,7 +69,7 @@ public class ConfigureJwtBearerOptions : IConfigureNamedOptions<JwtBearerOptions
                 }
 
                 // Invoked when a WebSocket or Long Polling request is received.
-                Log.Debug("Message received: " + context.Token);
+                Log.Debug("Message received. Token present: {TokenPresent}", !string.IsNullOrEmpty(context.Token));
                 return Task.CompletedTask;
             },
             OnChallenge = context =>


### PR DESCRIPTION
## Summary
- sanitize WebSocket token logging to avoid persisting raw JWTs

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ae245f08308327a24a291d3c2c1867