### PR TITLE
feat: add password login alternative

### DIFF
--- a/api/Avancira.API.Tests/AuthControllerTests.cs
+++ b/api/Avancira.API.Tests/AuthControllerTests.cs
@@ -7,6 +7,7 @@ using Avancira.Application.Auth.Dtos;
 using Avancira.Application.Identity;
 using Avancira.Application.Identity.Tokens.Dtos;
 using Avancira.Application.Identity.Tokens;
+using Avancira.Application.Identity.Users.Dtos;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -92,5 +93,50 @@ public class AuthControllerTests
 
         result.Result.Should().BeOfType<UnauthorizedResult>();
         authService.Verify(a => a.GenerateTokenAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Login_ReturnsTokensAndSetsCookie_OnSuccess()
+    {
+        var externalAuth = new Mock<IExternalAuthService>();
+        var externalUser = new Mock<IExternalUserService>();
+        var authService = new Mock<IAuthenticationService>();
+        var sessionService = new Mock<ISessionService>();
+
+        var controller = new AuthController(authService.Object, externalAuth.Object, externalUser.Object, sessionService.Object);
+        var httpContext = new DefaultHttpContext();
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        authService.Setup(a => a.PasswordSignInAsync("user@example.com", "Password1"))
+            .ReturnsAsync(new TokenPair("access", "refresh", DateTime.UtcNow.AddDays(1)));
+
+        var request = new LoginRequestDto { Email = "user@example.com", Password = "Password1" };
+
+        var result = await controller.Login(request);
+
+        var ok = result.Result as OkObjectResult;
+        ok.Should().NotBeNull();
+        var response = ok!.Value as TokenResponse;
+        response!.Token.Should().Be("access");
+        httpContext.Response.Headers["Set-Cookie"].ToString().Should().Contain("refreshtoken=refresh");
+    }
+
+    [Fact]
+    public async Task Login_ReturnsUnauthorized_OnInvalidCredentials()
+    {
+        var externalAuth = new Mock<IExternalAuthService>();
+        var externalUser = new Mock<IExternalUserService>();
+        var authService = new Mock<IAuthenticationService>();
+        var sessionService = new Mock<ISessionService>();
+
+        authService.Setup(a => a.PasswordSignInAsync("user@example.com", "bad"))
+            .ReturnsAsync((TokenPair?)null);
+
+        var controller = new AuthController(authService.Object, externalAuth.Object, externalUser.Object, sessionService.Object);
+
+        var request = new LoginRequestDto { Email = "user@example.com", Password = "bad" };
+        var result = await controller.Login(request);
+
+        result.Result.Should().BeOfType<UnauthorizedResult>();
     }
 }

--- a/api/Avancira.API.Tests/AuthenticationServiceTests.cs
+++ b/api/Avancira.API.Tests/AuthenticationServiceTests.cs
@@ -12,6 +12,8 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using Xunit;
+using Microsoft.AspNetCore.Identity;
+using Avancira.Domain.Identity;
 
 public class AuthenticationServiceTests
 {
@@ -36,7 +38,13 @@ public class AuthenticationServiceTests
         var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
         var httpFactory = new StubHttpClientFactory(httpClient);
 
-        var service = new AuthenticationService(httpFactory, clientInfoService, dbContext);
+        var userStore = new Mock<IUserStore<User>>();
+        var userManager = new Mock<UserManager<User>>(userStore.Object, null, null, null, null, null, null, null, null);
+        var contextAccessor = new Mock<IHttpContextAccessor>();
+        var claimsFactory = new Mock<IUserClaimsPrincipalFactory<User>>();
+        var signInManager = new Mock<SignInManager<User>>(userManager.Object, contextAccessor.Object, claimsFactory.Object, null, null, null, null);
+
+        var service = new AuthenticationService(httpFactory, clientInfoService, dbContext, userManager.Object, signInManager.Object);
 
         var userId = "user1";
         await service.GenerateTokenAsync(userId);

--- a/api/Avancira.API/Controllers/AuthController.cs
+++ b/api/Avancira.API/Controllers/AuthController.cs
@@ -2,6 +2,7 @@ using Avancira.Application.Identity;
 using Avancira.Application.Auth;
 using Avancira.Application.Auth.Dtos;
 using Avancira.Application.Identity.Tokens;
+using Avancira.Application.Identity.Users.Dtos;
 using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Cryptography;
@@ -29,6 +30,20 @@ public class AuthController : BaseApiController
         _externalAuthService = externalAuthService;
         _externalUserService = externalUserService;
         _sessionService = sessionService;
+    }
+
+    [HttpPost("login")]
+    [AllowAnonymous]
+    public async Task<ActionResult<TokenResponse>> Login([FromBody] LoginRequestDto request)
+    {
+        var pair = await _authenticationService.PasswordSignInAsync(request.Email, request.Password);
+        if (pair is null)
+        {
+            return Unauthorized();
+        }
+
+        SetRefreshTokenCookie(pair.RefreshToken, pair.RefreshTokenExpiryTime);
+        return Ok(new TokenResponse(pair.Token));
     }
 
     [HttpPost("external-login")]

--- a/api/Avancira.Application/Identity/IAuthenticationService.cs
+++ b/api/Avancira.Application/Identity/IAuthenticationService.cs
@@ -7,5 +7,6 @@ public interface IAuthenticationService
     Task<TokenPair> ExchangeCodeAsync(string code, string codeVerifier, string redirectUri);
     Task<TokenPair> GenerateTokenAsync(string userId);
     Task<TokenPair> RefreshTokenAsync(string refreshToken);
+    Task<TokenPair?> PasswordSignInAsync(string email, string password);
 }
 


### PR DESCRIPTION
## Summary
- allow authentication with email/password using OpenIddict tokens
- add ASP.NET Identity credential check to authentication service
- cover new login endpoint with unit tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2654c030832789c7611ae7aba9a7