### PR TITLE
feat: add email login flow

### DIFF
--- a/Frontend.Angular/src/app/models/token-response.ts
+++ b/Frontend.Angular/src/app/models/token-response.ts
@@ -1,0 +1,3 @@
+export interface TokenResponse {
+  token: string;
+}

--- a/Frontend.Angular/src/app/pages/signin/signin.component.ts
+++ b/Frontend.Angular/src/app/pages/signin/signin.component.ts
@@ -72,7 +72,16 @@ export class SigninComponent implements OnInit {
 
   /** Regular login */
   onLogin(): void {
-    this.authService.startLogin(this.returnUrl);
+    const { email, password } = this.loginForm.value;
+    this.authService.login(email, password, this.returnUrl).subscribe({
+      next: () => {
+        this.router.navigateByUrl(this.returnUrl);
+      },
+      error: (err) => {
+        console.error('Login failed:', err);
+        this.toastr.error('Invalid email or password.', 'Login Failed');
+      },
+    });
   }
 
   authenticate(provider: SocialProvider): void {


### PR DESCRIPTION
## Summary
- add `login` method in `AuthService` with credential handling and token storage
- wire up sign-in form to call email/password login
- define `TokenResponse` interface for login response

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2d95a0b88327adc220edbe46e2d4