### PR TITLE
Enable password grant support

### DIFF
--- a/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
+++ b/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
@@ -23,6 +23,7 @@ public static class OpenIddictSetup
 
                 options.AllowRefreshTokenFlow()
                        .AllowAuthorizationCodeFlow()
+                       .AllowPasswordFlow()
                        .RequireProofKeyForCodeExchange();
 
                 options.RegisterScopes("api");
@@ -39,6 +40,8 @@ public static class OpenIddictSetup
                     builder.UseScopedHandler<ExternalLoginHandler>());
                 options.AddEventHandler<ProcessSignInContext>(builder =>
                     builder.UseScopedHandler<DeviceInfoClaimsHandler>());
+                options.AddEventHandler<HandleTokenRequestContext>(builder =>
+                    builder.UseScopedHandler<PasswordGrantHandler>());
             })
             .AddValidation(options =>
             {

--- a/api/Avancira.Infrastructure/Identity/PasswordGrantHandler.cs
+++ b/api/Avancira.Infrastructure/Identity/PasswordGrantHandler.cs
@@ -1,0 +1,66 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Identity;
+using OpenIddict.Abstractions;
+using OpenIddict.Server;
+using OpenIddict.Server.AspNetCore;
+using OpenIddict.Server.Events;
+using Avancira.Infrastructure.Identity.Users;
+
+namespace Avancira.Infrastructure.Identity;
+
+public class PasswordGrantHandler : IOpenIddictServerHandler<HandleTokenRequestContext>
+{
+    private readonly UserManager<User> _userManager;
+    private readonly SignInManager<User> _signInManager;
+
+    public PasswordGrantHandler(UserManager<User> userManager, SignInManager<User> signInManager)
+    {
+        _userManager = userManager;
+        _signInManager = signInManager;
+    }
+
+    public async ValueTask HandleAsync(HandleTokenRequestContext context)
+    {
+        if (!context.Request.IsPasswordGrantType())
+        {
+            return;
+        }
+
+        var email = context.Request.Username;
+        var password = context.Request.Password;
+
+        if (string.IsNullOrEmpty(email) || string.IsNullOrEmpty(password))
+        {
+            return;
+        }
+
+        var user = await _userManager.FindByEmailAsync(email);
+        if (user is null)
+        {
+            return;
+        }
+
+        var result = await _signInManager.CheckPasswordSignInAsync(user, password, false);
+        if (!result.Succeeded)
+        {
+            return;
+        }
+
+        var identity = new ClaimsIdentity(OpenIddictServerAspNetCoreDefaults.AuthenticationType);
+        identity.SetClaim(OpenIddictConstants.Claims.Subject, user.Id);
+        if (!string.IsNullOrEmpty(user.Email))
+        {
+            identity.SetClaim(OpenIddictConstants.Claims.Email, user.Email);
+        }
+        if (!string.IsNullOrEmpty(user.UserName))
+        {
+            identity.SetClaim(OpenIddictConstants.Claims.Name, user.UserName);
+        }
+
+        var principal = new ClaimsPrincipal(identity);
+        principal.SetScopes(context.Request.GetScopes());
+
+        context.Principal = principal;
+        context.HandleRequest();
+    }
+}


### PR DESCRIPTION
## Summary
- allow password flow in OpenIddict server configuration
- add PasswordGrantHandler to validate username/password token requests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae30e669048327b4af9e3d7b026197