### PR TITLE
Allow refresh token cookie for root path

### DIFF
--- a/api/Avancira.API.Tests/AuthControllerTests.cs
+++ b/api/Avancira.API.Tests/AuthControllerTests.cs
@@ -8,6 +8,12 @@ using Avancira.Application.Identity.Users.Dtos;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Avancira.Infrastructure.Auth;
 using Moq;
 using Xunit;
 
@@ -52,5 +58,51 @@ public class AuthControllerTests
         var result = await controller.Login(request);
 
         result.Result.Should().BeOfType<UnauthorizedResult>();
+    }
+
+    [Fact]
+    public async Task Refresh_ReturnsTokenAndSetsCookie_OnSuccess()
+    {
+        var authService = new Mock<IAuthenticationService>();
+        var sessionService = new Mock<ISessionService>();
+
+        var controller = new AuthController(authService.Object, sessionService.Object);
+
+        var envMock = new Mock<IHostEnvironment>();
+        envMock.SetupGet(e => e.EnvironmentName).Returns(Environments.Production);
+        var services = new ServiceCollection();
+        services.AddSingleton(envMock.Object);
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider()
+        };
+        httpContext.Request.Cookies = new RequestCookieCollection(
+            new Dictionary<string, string> { ["refreshToken"] = "oldrefresh" });
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.WriteToken(new JwtSecurityToken(
+            claims: new[] { new Claim(JwtRegisteredClaimNames.Sub, "user1") }));
+        var pair = new TokenPair(jwt, "newrefresh", DateTime.UtcNow.AddDays(1));
+
+        authService.Setup(a => a.RefreshTokenAsync("oldrefresh")).ReturnsAsync(pair);
+
+        var info = (UserId: "user1", RefreshTokenId: Guid.NewGuid());
+        sessionService
+            .Setup(s => s.GetRefreshTokenInfoAsync(TokenUtilities.HashToken("oldrefresh")))
+            .ReturnsAsync(info);
+        sessionService
+            .Setup(s => s.RotateRefreshTokenAsync(info.RefreshTokenId, It.IsAny<string>(), It.IsAny<DateTime>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await controller.Refresh();
+
+        var ok = result.Result as OkObjectResult;
+        ok.Should().NotBeNull();
+        var response = ok!.Value as TokenResponse;
+        response!.Token.Should().Be(jwt);
+        var setCookie = httpContext.Response.Headers["Set-Cookie"].ToString().ToLowerInvariant();
+        setCookie.Should().Contain("refreshtoken=newrefresh");
+        setCookie.Should().Contain("path=/");
     }
 }

--- a/api/Avancira.API.Tests/BaseApiControllerTests.cs
+++ b/api/Avancira.API.Tests/BaseApiControllerTests.cs
@@ -39,7 +39,7 @@ public class BaseApiControllerTests
 
         var setCookie = httpContext.Response.Headers["Set-Cookie"].ToString().ToLowerInvariant();
         setCookie.Should().Contain("refreshtoken=token123");
-        setCookie.Should().Contain("path=/api/auth");
+        setCookie.Should().Contain("path=/");
         setCookie.Should().Contain("httponly");
         setCookie.Should().Contain("samesite=none");
         setCookie.Should().Contain("secure");
@@ -65,7 +65,7 @@ public class BaseApiControllerTests
 
         var setCookie = httpContext.Response.Headers["Set-Cookie"].ToString().ToLowerInvariant();
         setCookie.Should().Contain("refreshtoken=token456");
-        setCookie.Should().Contain("path=/api/auth");
+        setCookie.Should().Contain("path=/");
         setCookie.Should().Contain("httponly");
         setCookie.Should().Contain("samesite=none");
         setCookie.Should().Contain("secure");

--- a/api/Avancira.API/Controllers/BaseApiController.cs
+++ b/api/Avancira.API/Controllers/BaseApiController.cs
@@ -63,7 +63,7 @@ public abstract class BaseApiController : ControllerBase
         {
             HttpOnly = true,
             SameSite = SameSiteMode.None,
-            Path = "/api/auth"
+            Path = "/"
         };
 
         if (expires.HasValue)


### PR DESCRIPTION
## Summary
- make refresh token cookie available site-wide
- verify cookie path in controller tests
- add integration test for auth token refresh

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3f71a938832797f8e6c83df77a15