### PR TITLE
Validate external auth provider

### DIFF
--- a/api/Avancira.API.Tests/ExternalAuthControllerTests.cs
+++ b/api/Avancira.API.Tests/ExternalAuthControllerTests.cs
@@ -1,0 +1,34 @@
+using Avancira.API.Controllers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+public class ExternalAuthControllerTests
+{
+    [Theory]
+    [InlineData("google")]
+    [InlineData("facebook")]
+    public void ExternalLogin_WithValidProvider_Redirects(string provider)
+    {
+        var controller = new ExternalAuthController();
+
+        var result = controller.ExternalLogin(provider);
+
+        result.Should().BeOfType<RedirectResult>()
+            .Which.Url.Should().Be($"/connect/authorize?provider={provider}");
+    }
+
+    [Theory]
+    [InlineData("twitter")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ExternalLogin_WithInvalidProvider_ReturnsBadRequest(string? provider)
+    {
+        var controller = new ExternalAuthController();
+
+        var result = controller.ExternalLogin(provider!);
+
+        result.Should().BeOfType<BadRequestResult>();
+    }
+}
+

--- a/api/Avancira.API/Controllers/ExternalAuthController.cs
+++ b/api/Avancira.API/Controllers/ExternalAuthController.cs
@@ -1,3 +1,4 @@
+using Avancira.Application.Auth;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -11,6 +12,14 @@ public class ExternalAuthController : BaseApiController
     [AllowAnonymous]
     public IActionResult ExternalLogin([FromQuery] string provider)
     {
-        return Redirect($"/connect/authorize?provider={provider}");
+        if (string.IsNullOrWhiteSpace(provider) ||
+            !Enum.TryParse<SocialProvider>(provider, true, out var parsed))
+        {
+            return BadRequest();
+        }
+
+        var normalized = parsed.ToString().ToLowerInvariant();
+
+        return Redirect($"/connect/authorize?provider={normalized}");
     }
 }


### PR DESCRIPTION
## Summary
- restrict external authentication to known providers
- test redirection for valid providers and rejection for invalid ones

## Testing
- `dotnet test api/Avancira.API.Tests/Avancira.API.Tests.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3fa6cc608327b99e747daf292063