### PR TITLE
Use OAuthService helpers for login token processing

### DIFF
--- a/Frontend.Angular/src/app/services/auth.service.spec.ts
+++ b/Frontend.Angular/src/app/services/auth.service.spec.ts
@@ -23,7 +23,9 @@ describe('AuthService', () => {
       'refreshToken',
       'initCodeFlow',
       'logOut',
-      'getIdentityClaims'
+      'getIdentityClaims',
+      'processIdToken',
+      'tryLogin'
     ]);
 
     routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'createUrlTree']);


### PR DESCRIPTION
## Summary
- use OAuthService `processIdToken`/`tryLogin` to persist login token and its expiry
- drop manual JWT decoding
- update AuthService test spies for new OAuthService methods

## Testing
- `npm test` *(fails: Module not found: Can't resolve 'angular-oauth2-oidc')*

------
https://chatgpt.com/codex/tasks/task_e_68aec4bcac148327a0e916a84c33ff80