### PR TITLE
refactor token response parsing and configure fallback

### DIFF
--- a/api/Avancira.API.Tests/AuthenticationServiceTests.cs
+++ b/api/Avancira.API.Tests/AuthenticationServiceTests.cs
@@ -15,6 +15,8 @@ using Moq;
 using Xunit;
 using Microsoft.AspNetCore.Identity;
 using Avancira.Domain.Identity;
+using Avancira.Application.Auth.Jwt;
+using Microsoft.Extensions.Options;
 
 public class AuthenticationServiceTests
 {
@@ -45,7 +47,8 @@ public class AuthenticationServiceTests
         var claimsFactory = new Mock<IUserClaimsPrincipalFactory<User>>();
         var signInManager = new Mock<SignInManager<User>>(userManager.Object, contextAccessor.Object, claimsFactory.Object, null, null, null, null);
 
-        var service = new AuthenticationService(httpFactory, clientInfoService, dbContext, userManager.Object, signInManager.Object);
+        var jwtOptions = Options.Create(new JwtOptions());
+        var service = new AuthenticationService(httpFactory, clientInfoService, dbContext, userManager.Object, signInManager.Object, jwtOptions);
 
         var userId = "user1";
         await service.GenerateTokenAsync(userId);

--- a/api/Avancira.Application/Auth/Jwt/JwtOptions.cs
+++ b/api/Avancira.Application/Auth/Jwt/JwtOptions.cs
@@ -13,6 +13,8 @@ public class JwtOptions : IValidatableObject
 
     public int RefreshTokenExpirationInDays { get; set; } = 7;
 
+    public int RefreshTokenDefaultDays { get; set; } = 7;
+
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
         if (string.IsNullOrEmpty(Key))


### PR DESCRIPTION
## Summary
- centralize access and refresh token parsing with `ParseTokenResponseAsync`
- inject `JwtOptions` and move refresh token default days to configuration
- adjust tests for new authentication service constructor

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aedec85bb88327896e97708a07faf1