### PR TITLE
chore: update OpenIddict packages to v7

### DIFF
--- a/api/Avancira.API/Avancira.API.csproj
+++ b/api/Avancira.API/Avancira.API.csproj
@@ -25,8 +25,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="9.0.3" />
-    <PackageReference Include="OpenIddict.Server.AspNetCore" Version="5.*" />
-    <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="5.*" />
+    <PackageReference Include="OpenIddict.Server.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="7.0.0" />
   </ItemGroup>
 
   


### PR DESCRIPTION
## Summary
- update OpenIddict.Server.AspNetCore to v7
- update OpenIddict.Validation.AspNetCore to v7

## Testing
- `dotnet restore api/Avancira.API/Avancira.API.csproj` *(fails: command not found: dotnet)*
- `dotnet build Avancira.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68aee987205c83278ad32b459ce5ca09