### PR TITLE
chore: upgrade OpenIddict EF Core

### DIFF
--- a/api/Avancira.Infrastructure/Avancira.Infrastructure.csproj
+++ b/api/Avancira.Infrastructure/Avancira.Infrastructure.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.3" />
-    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="5.5.0" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="7.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- upgrade OpenIddict.EntityFrameworkCore to version 7.0.0

## Testing
- `dotnet restore api/Avancira.Infrastructure/Avancira.Infrastructure.csproj` *(fails: command not found: dotnet)*
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68aeeaed5c9883279a01c073bef1a804