### PR TITLE
Use shared current user service in API controllers

### DIFF
--- a/api/Avancira.API/Controllers/BaseApiController.cs
+++ b/api/Avancira.API/Controllers/BaseApiController.cs
@@ -11,29 +11,6 @@ namespace Avancira.API.Controllers;
 public abstract class BaseApiController : ControllerBase
 {
     /// <summary>
-    /// Gets the current user's ID from JWT claims
-    /// </summary>
-    /// <returns>User ID if authenticated, otherwise null</returns>
-    protected string? GetUserId()
-    {
-        var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value
-                    ?? User.FindFirst("sub")?.Value
-                    ?? User.FindFirst("userId")?.Value;
-
-        return string.IsNullOrEmpty(userId) ? null : userId;
-    }
-
-    /// <summary>
-    /// Gets the current user's email from JWT claims
-    /// </summary>
-    /// <returns>User email if available, otherwise null</returns>
-    protected string? GetUserEmail()
-    {
-        return User.FindFirst(ClaimTypes.Email)?.Value 
-               ?? User.FindFirst("email")?.Value;
-    }
-
-    /// <summary>
     /// Gets the current user's roles from JWT claims
     /// </summary>
     /// <returns>List of user roles</returns>

--- a/api/Avancira.API/Controllers/ChatsController.cs
+++ b/api/Avancira.API/Controllers/ChatsController.cs
@@ -1,5 +1,6 @@
 using Avancira.Application.Catalog;
 using Avancira.Application.Catalog.Dtos;
+using Avancira.Application.Identity.Users.Abstractions;
 using Avancira.Application.Messaging;
 using Avancira.Application.Messaging.Dtos;
 using Microsoft.AspNetCore.Authorization;
@@ -13,16 +14,19 @@ public class ChatsController : BaseApiController
     private readonly IChatService _chatService;
     private readonly IListingService _listingService;
     private readonly ILogger<ChatsController> _logger;
+    private readonly ICurrentUser _currentUser;
 
     public ChatsController(
         IChatService chatService,
         IListingService listingService,
-        ILogger<ChatsController> logger
+        ILogger<ChatsController> logger,
+        ICurrentUser currentUser
     )
     {
         _chatService = chatService;
         _listingService = listingService;
         _logger = logger;
+        _currentUser = currentUser;
     }
 
     // Read
@@ -30,11 +34,7 @@ public class ChatsController : BaseApiController
     [HttpGet]
     public IActionResult GetUserChats()
     {
-        var userId = GetUserId();
-        if (userId is null)
-        {
-            return Unauthorized();
-        }
+        var userId = _currentUser.GetUserId().ToString();
         var chats = _chatService.GetUserChats(userId);
         return Ok(chats);
     }
@@ -43,11 +43,7 @@ public class ChatsController : BaseApiController
     [HttpGet("{id:guid}")]
     public IActionResult GetChatById(Guid id)
     {
-        var userId = GetUserId();
-        if (userId is null)
-        {
-            return Unauthorized();
-        }
+        var userId = _currentUser.GetUserId().ToString();
         var chat = _chatService.GetChat(id, userId);
         if (chat.Id == Guid.Empty)
         {
@@ -76,11 +72,7 @@ public class ChatsController : BaseApiController
         }
 
         // Check if a chat already exists
-        var senderId = GetUserId();
-        if (senderId is null)
-        {
-            return Unauthorized();
-        }
+        var senderId = _currentUser.GetUserId().ToString();
 
         if (!await _chatService.SendMessageAsync(messageDto, senderId))
         {

--- a/api/Avancira.API/Controllers/EvaluationsController.cs
+++ b/api/Avancira.API/Controllers/EvaluationsController.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using Avancira.Application.Catalog;
 using Avancira.Application.Catalog.Dtos;
+using Avancira.Application.Identity.Users.Abstractions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -12,14 +13,17 @@ public class EvaluationsController : BaseApiController
 {
     private readonly IEvaluationService _evaluationService;
     private readonly ILogger<EvaluationsController> _logger;
+    private readonly ICurrentUser _currentUser;
 
     public EvaluationsController(
         IEvaluationService evaluationService,
-        ILogger<EvaluationsController> logger
+        ILogger<EvaluationsController> logger,
+        ICurrentUser currentUser
     )
     {
         _evaluationService = evaluationService;
         _logger = logger;
+        _currentUser = currentUser;
     }
 
     // Create
@@ -27,11 +31,7 @@ public class EvaluationsController : BaseApiController
     [HttpPost("review")]
     public async Task<IActionResult> LeaveReviewAsync([FromBody] ReviewDto reviewDto)
     {
-        var userId = GetUserId();
-        if (userId is null)
-        {
-            return Unauthorized();
-        }
+        var userId = _currentUser.GetUserId().ToString();
 
         // Validate the input
         if (reviewDto == null)
@@ -60,11 +60,7 @@ public class EvaluationsController : BaseApiController
     [HttpPost("recommendation")]
     public async Task<IActionResult> SubmitRecommendation([FromBody] ReviewDto dto)
     {
-        var userId = GetUserId();
-        if (userId is null)
-        {
-            return Unauthorized();
-        }
+        var userId = _currentUser.GetUserId().ToString();
 
         if (string.IsNullOrEmpty(dto.RevieweeId) || string.IsNullOrEmpty(dto.Feedback))
             return BadRequest("Invalid data.");
@@ -86,11 +82,7 @@ public class EvaluationsController : BaseApiController
     [HttpGet]
     public async Task<IActionResult> GetEvaluationsAsync()
     {
-        var userId = GetUserId();
-        if (userId is null)
-        {
-            return Unauthorized();
-        }
+        var userId = _currentUser.GetUserId().ToString();
 
         // Identify pending reviews based on the user's role
         var pendingReviews = await _evaluationService.GetPendingReviewsAsync(userId);

--- a/api/Avancira.API/Controllers/LessonsController.cs
+++ b/api/Avancira.API/Controllers/LessonsController.cs
@@ -1,3 +1,4 @@
+using Avancira.Application.Identity.Users.Abstractions;
 using Avancira.Application.Lessons.Dtos;
 using Avancira.Application.Lessons;
 using Microsoft.AspNetCore.Authorization;
@@ -10,14 +11,17 @@ public class LessonsController : BaseApiController
 {
     private readonly ILessonService _lessonService;
     private readonly ILogger<LessonsController> _logger;
+    private readonly ICurrentUser _currentUser;
 
     public LessonsController(
         ILessonService lessonService,
-        ILogger<LessonsController> logger
+        ILogger<LessonsController> logger,
+        ICurrentUser currentUser
     )
     {
         _lessonService = lessonService;
         _logger = logger;
+        _currentUser = currentUser;
     }
 
     // Create
@@ -25,11 +29,7 @@ public class LessonsController : BaseApiController
     [HttpPost("proposeLesson")]
     public async Task<IActionResult> ProposeLessonAsync([FromBody] LessonDto lessonDto)
     {
-        var userId = GetUserId();
-        if (userId is null)
-        {
-            return Unauthorized();
-        }
+        var userId = _currentUser.GetUserId().ToString();
         var result = await _lessonService.ProposeLessonAsync(lessonDto, userId);
         return Ok(new { Message = "Lesson proposed successfully.", Lesson = result });
     }
@@ -39,11 +39,7 @@ public class LessonsController : BaseApiController
     [HttpGet("{contactId}/{listingId}")]
     public async Task<IActionResult> GetLessonsAsync(string contactId, Guid listingId, [FromQuery] int page = 1, [FromQuery] int pageSize = 10)
     {
-        var userId = GetUserId();
-        if (userId is null)
-        {
-            return Unauthorized();
-        }
+        var userId = _currentUser.GetUserId().ToString();
         var lessons = await _lessonService.GetLessonsAsync(contactId, userId, listingId, page, pageSize);
         return Ok(new { Lessons = lessons });
     }
@@ -57,11 +53,7 @@ public class LessonsController : BaseApiController
             return BadRequest("Invalid page or pageSize parameters.");
         }
 
-        var userId = GetUserId();
-        if (userId is null)
-        {
-            return Unauthorized();
-        }
+        var userId = _currentUser.GetUserId().ToString();
         var lessons = await _lessonService.GetAllLessonsAsync(userId, filters);
         return Ok(new { Lessons = lessons });
     }
@@ -71,11 +63,7 @@ public class LessonsController : BaseApiController
     [HttpPut("respondToProposition/{lessonId}")]
     public async Task<IActionResult> RespondToPropositionAsync(Guid lessonId, [FromBody] bool accept)
     {
-        var userId = GetUserId();
-        if (userId is null)
-        {
-            return Unauthorized();
-        }
+        var userId = _currentUser.GetUserId().ToString();
         LessonDto updatedLesson;
         try
         {
@@ -104,11 +92,7 @@ public class LessonsController : BaseApiController
     {
         try
         {
-            var userId = GetUserId();
-            if (userId is null)
-            {
-                return Unauthorized();
-            }
+            var userId = _currentUser.GetUserId().ToString();
             var canceledLesson = await _lessonService.UpdateLessonStatusAsync(lessonId, false, userId);
 
             return Ok(new

--- a/api/Avancira.API/Controllers/SubscriptionsController.cs
+++ b/api/Avancira.API/Controllers/SubscriptionsController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Avancira.Application.Catalog;
 using Avancira.Application.Catalog.Dtos;
+using Avancira.Application.Identity.Users.Abstractions;
 using Avancira.Application.Subscriptions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -12,12 +13,15 @@ namespace Avancira.API.Controllers;
 public class SubscriptionsController : BaseApiController
 {
     private readonly ISubscriptionService _subscriptionService;
+    private readonly ICurrentUser _currentUser;
 
     public SubscriptionsController(
-        ISubscriptionService subscriptionService
+        ISubscriptionService subscriptionService,
+        ICurrentUser currentUser
     )
     {
         _subscriptionService = subscriptionService;
+        _currentUser = currentUser;
     }
 
     // Create
@@ -27,11 +31,7 @@ public class SubscriptionsController : BaseApiController
     {
         try
         {
-            var userId = GetUserId();
-            if (userId is null)
-            {
-                return Unauthorized();
-            }
+            var userId = _currentUser.GetUserId().ToString();
             var (subscriptionId, transactionId) = await _subscriptionService.CreateSubscriptionAsync(request, userId);
             return Ok(new { SubscriptionId = subscriptionId, TransactionId = transactionId });
         }
@@ -50,11 +50,7 @@ public class SubscriptionsController : BaseApiController
     [HttpGet("check-active")]
     public async Task<IActionResult> CheckActiveSubscription()
     {
-        var userId = GetUserId();
-        if (userId is null)
-        {
-            return Unauthorized();
-        }
+        var userId = _currentUser.GetUserId().ToString();
         var hasActiveSubscription = await _subscriptionService.HasActiveSubscriptionAsync(userId);
         return Ok(new { IsActive = hasActiveSubscription });
     }
@@ -63,11 +59,7 @@ public class SubscriptionsController : BaseApiController
     [HttpGet("")]
     public async Task<IActionResult> GetUserSubscriptions([FromQuery] int page = 1, [FromQuery] int pageSize = 10)
     {
-        var userId = GetUserId();
-        if (userId is null)
-        {
-            return Unauthorized();
-        }
+        var userId = _currentUser.GetUserId().ToString();
         var subscriptions = await _subscriptionService.ListUserSubscriptionsAsync(userId, page, pageSize);
 
         if (subscriptions == null || subscriptions.TotalResults == 0)
@@ -99,11 +91,7 @@ public class SubscriptionsController : BaseApiController
     [HttpGet("details")]
     public async Task<IActionResult> GetSubscriptionDetails()
     {
-        var userId = GetUserId();
-        if (userId is null)
-        {
-            return Unauthorized();
-        }
+        var userId = _currentUser.GetUserId().ToString();
         var details = await _subscriptionService.FetchSubscriptionDetailsAsync(userId);
         if (details == null) return NotFound(new { Message = "No active subscription found." });
 
@@ -115,11 +103,7 @@ public class SubscriptionsController : BaseApiController
     [HttpPut("change-frequency")]
     public async Task<IActionResult> ChangeBillingFrequency([FromBody] ChangeFrequencyRequestDto request)
     {
-        var userId = GetUserId();
-        if (userId is null)
-        {
-            return Unauthorized();
-        }
+        var userId = _currentUser.GetUserId().ToString();
         var success = await _subscriptionService.ChangeBillingFrequencyAsync(userId, request.NewFrequency);
 
         if (!success)
@@ -133,11 +117,7 @@ public class SubscriptionsController : BaseApiController
     [HttpDelete("cancel")]
     public async Task<IActionResult> CancelSubscription()
     {
-        var userId = GetUserId();
-        if (userId is null)
-        {
-            return Unauthorized();
-        }
+        var userId = _currentUser.GetUserId().ToString();
         var success = await _subscriptionService.CancelSubscriptionAsync(userId);
 
         if (!success)

--- a/api/Avancira.API/Controllers/WalletsController.cs
+++ b/api/Avancira.API/Controllers/WalletsController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Avancira.Application.Catalog;
+using Avancira.Application.Identity.Users.Abstractions;
 using Avancira.Application.Payments;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -11,12 +12,15 @@ namespace Avancira.API.Controllers;
 public class WalletsController : BaseApiController
 {
     private readonly IWalletService _walletService;
+    private readonly ICurrentUser _currentUser;
 
     public WalletsController(
-        IWalletService walletService
+        IWalletService walletService,
+        ICurrentUser currentUser
     )
     {
         _walletService = walletService;
+        _currentUser = currentUser;
     }
 
     // Create
@@ -44,11 +48,7 @@ public class WalletsController : BaseApiController
     {
         try
         {
-            var userId = GetUserId();
-            if (userId is null)
-            {
-                return Unauthorized();
-            }
+            var userId = _currentUser.GetUserId().ToString();
             var result = await _walletService.GetWalletBalanceAsync(userId);
             return Ok(new { Balance = result.Balance, LastUpdated = result.LastUpdated });
         }


### PR DESCRIPTION
## Summary
- inject `ICurrentUser` into controllers that need access to the authenticated user
- remove redundant helpers from `BaseApiController`
- rely on `_currentUser.GetUserId()` for user identification

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68af3ffdb7b8832787a58416a9707b4b