### PR TITLE
Read issuer from configuration

### DIFF
--- a/api/Avancira.API/appsettings.Development.json
+++ b/api/Avancira.API/appsettings.Development.json
@@ -11,6 +11,9 @@
   "App": {
     "FrontendUrl": "https://localhost:4200"
   },
+  "Auth": {
+    "Issuer": "https://localhost:9000/"
+  },
   "Avancira": {
     "ExternalServices": {
       "Google": {

--- a/api/Avancira.API/appsettings.json
+++ b/api/Avancira.API/appsettings.json
@@ -9,6 +9,9 @@
   "App": {
     "FrontendUrl": "https://www.avancira.com"
   },
+  "Auth": {
+    "Issuer": "{Avancira__Auth__Issuer}"
+  },
   "CacheOptions": {
     "Redis": ""
   },

--- a/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
+++ b/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
@@ -6,9 +6,10 @@ namespace Avancira.Infrastructure.Identity;
 
 public static class OpenIddictSetup
 {
-    public static IServiceCollection AddOpenIddictServer(this IServiceCollection services)
+    public static IServiceCollection AddOpenIddictServer(this IServiceCollection services, IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
 
         services.AddOpenIddict()
             .AddServer(options =>
@@ -16,7 +17,7 @@ public static class OpenIddictSetup
                 options.SetAuthorizationEndpointUris("/connect/authorize")
                        .SetTokenEndpointUris("/connect/token")
                        .SetRevocationEndpointUris("/connect/revocation")
-                       .SetIssuer(new Uri("https://localhost:9000/"));
+                       .SetIssuer(new Uri(configuration["Auth:Issuer"]!));
 
                 options.AllowRefreshTokenFlow()
                        .AllowAuthorizationCodeFlow()
@@ -54,7 +55,7 @@ public static class OpenIddictSetup
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
-        services.AddOpenIddictServer();
+        services.AddOpenIddictServer(configuration);
 
         return services;
     }

--- a/aspire/Avancira.Host/Program.cs
+++ b/aspire/Avancira.Host/Program.cs
@@ -52,6 +52,8 @@ builder.AddProject<Projects.Avancira_API>("avancira-backend-container")
     .WithEnvironment("Avancira__App__Name", Environment.GetEnvironmentVariable("Avancira__App__Name") ?? string.Empty)
     .WithEnvironment("Avancira__App__SupportEmail", Environment.GetEnvironmentVariable("Avancira__App__SupportEmail") ?? string.Empty)
     .WithEnvironment("Avancira__App__SupportPhone", Environment.GetEnvironmentVariable("Avancira__App__SupportPhone") ?? string.Empty)
+    // Auth Configuration
+    .WithEnvironment("Avancira__Auth__Issuer", Environment.GetEnvironmentVariable("Avancira__Auth__Issuer") ?? string.Empty)
     // JWT Configuration
     .WithEnvironment("Avancira__Jwt__Audience", Environment.GetEnvironmentVariable("Avancira__Jwt__Audience") ?? string.Empty)
     .WithEnvironment("Avancira__Jwt__Issuer", Environment.GetEnvironmentVariable("Avancira__Jwt__Issuer") ?? string.Empty)


### PR DESCRIPTION
## Summary
- configure OpenIddict issuer using configuration instead of hard-coded URL
- add Auth:Issuer setting for API and AspNet host environment
- provide Auth issuer entries in appsettings and development configuration

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af4577f5bc8327abe2bce3b0f27569