### PR TITLE
Restrict OpenIddict server to auth code and password flows

### DIFF
--- a/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
+++ b/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
@@ -19,8 +19,7 @@ public static class OpenIddictSetup
                        .SetRevocationEndpointUris("/connect/revocation")
                        .SetIssuer(new Uri(configuration["Auth:Issuer"]!));
 
-                options.AllowRefreshTokenFlow()
-                       .AllowAuthorizationCodeFlow()
+                options.AllowAuthorizationCodeFlow()
                        .AllowPasswordFlow()
                        .RequireProofKeyForCodeExchange();
 


### PR DESCRIPTION
## Summary
- limit OpenIddict server to authorization code and password flows by removing refresh token flow

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af47ffdeb88327b35fa4bb024abfc3