### PR TITLE
Enable refresh tokens in OpenIddict server

### DIFF
--- a/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
+++ b/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
@@ -21,9 +21,10 @@ public static class OpenIddictSetup
 
                 options.AllowAuthorizationCodeFlow()
                        .AllowPasswordFlow()
+                       .AllowRefreshTokenFlow()
                        .RequireProofKeyForCodeExchange();
 
-                options.RegisterScopes("api");
+                options.RegisterScopes("api", "offline_access");
 
                 options.AddDevelopmentEncryptionCertificate()
                        .AddDevelopmentSigningCertificate();


### PR DESCRIPTION
## Summary
- allow refresh tokens for the OpenIddict server and register offline_access scope

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68af4b2905048327a10f66c5321cc901