### PR TITLE
Centralize authentication constants

### DIFF
--- a/api/Avancira.API.Tests/AuthenticationServiceTests.cs
+++ b/api/Avancira.API.Tests/AuthenticationServiceTests.cs
@@ -2,10 +2,12 @@ using System;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Avancira.Application.Common;
 using Avancira.Infrastructure.Auth;
+using System.Text.Json;
 using Avancira.Infrastructure.Persistence;
 using Avancira.Infrastructure.Identity.Tokens;
 using FluentAssertions;
@@ -37,7 +39,13 @@ public class AuthenticationServiceTests
         };
         var clientInfoService = new StubClientInfoService(clientInfo);
 
-        var handler = new StubHttpMessageHandler("{\"access_token\":\"token\",\"refresh_token\":\"refresh\",\"refresh_token_expires_in\":3600}");
+        var json = JsonSerializer.Serialize(new Dictionary<string, object>
+        {
+            [AuthConstants.Parameters.AccessToken] = "token",
+            [AuthConstants.Parameters.RefreshToken] = "refresh",
+            [AuthConstants.Parameters.RefreshTokenExpiresIn] = 3600
+        });
+        var handler = new StubHttpMessageHandler(json);
         var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
         var httpFactory = new StubHttpClientFactory(httpClient);
 

--- a/api/Avancira.API.Tests/ConfigureJwtBearerOptionsTests.cs
+++ b/api/Avancira.API.Tests/ConfigureJwtBearerOptionsTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Avancira.Application.Auth.Jwt;
 using Avancira.Application.Identity.Tokens;
 using Avancira.Infrastructure.Auth.Jwt;
+using Avancira.Infrastructure.Auth;
 using FluentAssertions;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -29,7 +30,7 @@ public class ConfigureJwtBearerOptionsTests
         var principal = new ClaimsPrincipal(new ClaimsIdentity(new[]
         {
             new Claim(ClaimTypes.NameIdentifier, userId),
-            new Claim("sid", sessionId.ToString())
+            new Claim(AuthConstants.Claims.SessionId, sessionId.ToString())
         }));
 
         var context = new TokenValidatedContext(
@@ -59,7 +60,7 @@ public class ConfigureJwtBearerOptionsTests
         var principal = new ClaimsPrincipal(new ClaimsIdentity(new[]
         {
             new Claim(ClaimTypes.NameIdentifier, userId),
-            new Claim("sid", sessionId.ToString())
+            new Claim(AuthConstants.Claims.SessionId, sessionId.ToString())
         }));
 
         var context = new TokenValidatedContext(

--- a/api/Avancira.API.Tests/ExternalAuthControllerTests.cs
+++ b/api/Avancira.API.Tests/ExternalAuthControllerTests.cs
@@ -2,6 +2,7 @@ using Avancira.API.Controllers;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
+using Avancira.Infrastructure.Auth;
 
 public class ExternalAuthControllerTests
 {
@@ -15,7 +16,7 @@ public class ExternalAuthControllerTests
         var result = controller.ExternalLogin(provider);
 
         result.Should().BeOfType<RedirectResult>()
-            .Which.Url.Should().Be($"/connect/authorize?provider={provider}");
+            .Which.Url.Should().Be($"{AuthConstants.Endpoints.Authorize}?{AuthConstants.Parameters.Provider}={provider}");
     }
 
     [Theory]

--- a/api/Avancira.API/Controllers/ExternalAuthController.cs
+++ b/api/Avancira.API/Controllers/ExternalAuthController.cs
@@ -1,6 +1,7 @@
 using Avancira.Application.Auth;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Avancira.Infrastructure.Auth;
 
 namespace Avancira.API.Controllers;
 
@@ -20,6 +21,6 @@ public class ExternalAuthController : BaseApiController
 
         var normalized = parsed.ToString().ToLowerInvariant();
 
-        return Redirect($"/connect/authorize?provider={normalized}");
+        return Redirect($"{AuthConstants.Endpoints.Authorize}?{AuthConstants.Parameters.Provider}={normalized}");
     }
 }

--- a/api/Avancira.API/Program.cs
+++ b/api/Avancira.API/Program.cs
@@ -8,6 +8,7 @@ using System.Threading.RateLimiting;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Avancira.Infrastructure.Identity;
+using Avancira.Infrastructure.Auth;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -90,7 +91,7 @@ app.UseRateLimiter();
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.MapHub<NotificationHub>("/notification");
+app.MapHub<NotificationHub>(AuthConstants.Endpoints.Notification);
 
 app.MapControllers();
 

--- a/api/Avancira.Infrastructure/Auth/AuthConstants.cs
+++ b/api/Avancira.Infrastructure/Auth/AuthConstants.cs
@@ -1,0 +1,46 @@
+namespace Avancira.Infrastructure.Auth;
+
+public static class AuthConstants
+{
+    public static class Endpoints
+    {
+        public const string Token = "/connect/token";
+        public const string Authorize = "/connect/authorize";
+        public const string Revocation = "/connect/revocation";
+        public const string Notification = "/notification";
+    }
+
+    public static class Parameters
+    {
+        public const string GrantType = "grant_type";
+        public const string Code = "code";
+        public const string RedirectUri = "redirect_uri";
+        public const string CodeVerifier = "code_verifier";
+        public const string DeviceId = "device_id";
+        public const string UserId = "user_id";
+        public const string Scope = "scope";
+        public const string RefreshToken = "refresh_token";
+        public const string AccessToken = "access_token";
+        public const string RefreshTokenExpiresIn = "refresh_token_expires_in";
+        public const string Provider = "provider";
+    }
+
+    public static class Claims
+    {
+        public const string SessionId = "sid";
+    }
+
+    public static class GrantTypes
+    {
+        public const string AuthorizationCode = "authorization_code";
+        public const string UserId = "user_id";
+        public const string RefreshToken = "refresh_token";
+    }
+
+    public static class Cookies
+    {
+        public const string RefreshToken = "refreshToken";
+        public const string PathRoot = "/";
+    }
+}
+

--- a/api/Avancira.Infrastructure/Auth/Jwt/ConfigureJwtBearerOptions.cs
+++ b/api/Avancira.Infrastructure/Auth/Jwt/ConfigureJwtBearerOptions.cs
@@ -58,7 +58,7 @@ public class ConfigureJwtBearerOptions : IConfigureNamedOptions<JwtBearerOptions
             OnTokenValidated = async context =>
             {
                 var userId = context.Principal?.FindFirstValue(ClaimTypes.NameIdentifier);
-                var sessionClaim = context.Principal?.FindFirst("sid")?.Value;
+                var sessionClaim = context.Principal?.FindFirst(AuthConstants.Claims.SessionId)?.Value;
                 if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(sessionClaim) || !Guid.TryParse(sessionClaim, out var sessionId))
                 {
                     context.Fail("Session revoked");
@@ -79,9 +79,9 @@ public class ConfigureJwtBearerOptions : IConfigureNamedOptions<JwtBearerOptions
             },
             OnMessageReceived = context =>
             {
-                var accessToken = context.Request.Query["access_token"];
+                var accessToken = context.Request.Query[AuthConstants.Parameters.AccessToken];
                 var path = context.HttpContext.Request.Path;
-                if (!string.IsNullOrEmpty(accessToken) && path.StartsWithSegments("/notification"))
+                if (!string.IsNullOrEmpty(accessToken) && path.StartsWithSegments(AuthConstants.Endpoints.Notification))
                 {
                     context.Token = accessToken;
                 }

--- a/api/Avancira.Infrastructure/Auth/RefreshTokenCookieService.cs
+++ b/api/Avancira.Infrastructure/Auth/RefreshTokenCookieService.cs
@@ -23,7 +23,7 @@ public class RefreshTokenCookieService : IRefreshTokenCookieService
         {
             HttpOnly = true,
             SameSite = SameSiteMode.None,
-            Path = "/",
+            Path = AuthConstants.Cookies.PathRoot,
             Secure = !_environment.IsDevelopment()
         };
 
@@ -32,7 +32,7 @@ public class RefreshTokenCookieService : IRefreshTokenCookieService
             options.Expires = expires.Value;
         }
 
-        context.Response.Cookies.Append("refreshToken", refreshToken, options);
+        context.Response.Cookies.Append(AuthConstants.Cookies.RefreshToken, refreshToken, options);
     }
 }
 

--- a/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
+++ b/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using static OpenIddict.Server.OpenIddictServerEvents;
+using Avancira.Infrastructure.Auth;
 
 namespace Avancira.Infrastructure.Identity;
 
@@ -14,9 +15,9 @@ public static class OpenIddictSetup
         services.AddOpenIddict()
             .AddServer(options =>
             {
-                options.SetAuthorizationEndpointUris("/connect/authorize")
-                       .SetTokenEndpointUris("/connect/token")
-                       .SetRevocationEndpointUris("/connect/revocation")
+                options.SetAuthorizationEndpointUris(AuthConstants.Endpoints.Authorize)
+                       .SetTokenEndpointUris(AuthConstants.Endpoints.Token)
+                       .SetRevocationEndpointUris(AuthConstants.Endpoints.Revocation)
                        .SetIssuer(new Uri(configuration["Auth:Issuer"]!));
 
                 options.AllowAuthorizationCodeFlow()


### PR DESCRIPTION
## Summary
- add `AuthConstants` with shared endpoint, parameter, claim and cookie names
- replace hard-coded authentication strings with the new constants
- update tests and configuration to use the centralized constants

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68af4f89d44483279ffaacfa4ca292f3