### PR TITLE
Use DTO for token response

### DIFF
--- a/api/Avancira.Application/Identity/Tokens/Dtos/TokenResponse.cs
+++ b/api/Avancira.Application/Identity/Tokens/Dtos/TokenResponse.cs
@@ -1,7 +1,27 @@
+using System.Text.Json.Serialization;
+
 namespace Avancira.Application.Identity.Tokens.Dtos;
 
 /// <summary>
-/// Response returned to the client after authentication or token refresh.
-/// Contains only the short-lived access token.
+/// Represents the response returned by the identity provider's token endpoint.
 /// </summary>
-public record TokenResponse(string Token);
+public sealed record TokenResponse
+{
+    /// <summary>
+    /// The short-lived access token.
+    /// </summary>
+    [JsonPropertyName("access_token")]
+    public string? AccessToken { get; init; }
+
+    /// <summary>
+    /// The refresh token allowing renewal of the access token.
+    /// </summary>
+    [JsonPropertyName("refresh_token")]
+    public string? RefreshToken { get; init; }
+
+    /// <summary>
+    /// Number of seconds until the refresh token expires, if provided.
+    /// </summary>
+    [JsonPropertyName("refresh_token_expires_in")]
+    public int? RefreshTokenExpiresIn { get; init; }
+}


### PR DESCRIPTION
## Summary
- add TokenResponse DTO for identity token endpoint
- parse HTTP token response via JsonSerializer

## Testing
- `dotnet test Avancira.sln --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af4fbd2a508327a2e2c562a5bdacb2