### PR TITLE
Add user authentication service

### DIFF
--- a/api/Avancira.Application/Identity/IUserAuthenticationService.cs
+++ b/api/Avancira.Application/Identity/IUserAuthenticationService.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Identity;
+using System.Security.Claims;
+
+namespace Avancira.Application.Identity;
+
+public interface IUserAuthenticationService
+{
+    Task<IdentityUser?> ValidateCredentialsAsync(string email, string password);
+    Task<ClaimsPrincipal> CreatePrincipalAsync(IdentityUser user);
+}
+

--- a/api/Avancira.Infrastructure/Identity/Extensions.cs
+++ b/api/Avancira.Infrastructure/Identity/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using Avancira.Application.Audit;
 using Avancira.Application.Identity.Roles;
+using Avancira.Application.Identity;
 using Avancira.Application.Identity.Users.Abstractions;
 using Avancira.Application.Identity.Tokens;
 using Avancira.Application.Persistence;
@@ -26,6 +27,7 @@ internal static class Extensions
         services.AddScoped(sp => (ICurrentUserInitializer)sp.GetRequiredService<ICurrentUser>());
         services.AddTransient<IdentityLinkBuilder>();
         services.AddTransient<Avancira.Application.Identity.Users.Abstractions.IUserService, UserService>();
+        services.AddTransient<IUserAuthenticationService, UserAuthenticationService>();
         services.AddTransient<IRoleService, RoleService>();
         services.AddTransient<ISessionService, SessionService>();
         services.AddTransient<IAuditService, AuditService>();

--- a/api/Avancira.Infrastructure/Identity/Users/UserAuthenticationService.cs
+++ b/api/Avancira.Infrastructure/Identity/Users/UserAuthenticationService.cs
@@ -1,0 +1,36 @@
+using System.Security.Claims;
+using Avancira.Application.Identity;
+using Microsoft.AspNetCore.Identity;
+
+namespace Avancira.Infrastructure.Identity.Users;
+
+public class UserAuthenticationService(
+    UserManager<User> userManager,
+    SignInManager<User> signInManager) : IUserAuthenticationService
+{
+    public async Task<IdentityUser?> ValidateCredentialsAsync(string email, string password)
+    {
+        if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(password))
+        {
+            return null;
+        }
+
+        var user = await userManager.FindByEmailAsync(email);
+        if (user is null)
+        {
+            return null;
+        }
+
+        var result = await signInManager.CheckPasswordSignInAsync(user, password, lockoutOnFailure: false);
+        if (!result.Succeeded)
+        {
+            return null;
+        }
+
+        return user;
+    }
+
+    public Task<ClaimsPrincipal> CreatePrincipalAsync(IdentityUser user)
+        => signInManager.CreateUserPrincipalAsync((User)user);
+}
+


### PR DESCRIPTION
## Summary
- introduce `IUserAuthenticationService` contract
- handle password grant via reusable user authentication service
- register user authentication service in DI

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af51d5e3cc83279a114a1e319d18a0