### PR TITLE
Simplify password grant validation

### DIFF
--- a/api/Avancira.Infrastructure/Identity/PasswordGrantHandler.cs
+++ b/api/Avancira.Infrastructure/Identity/PasswordGrantHandler.cs
@@ -22,18 +22,11 @@ public class PasswordGrantHandler : IOpenIddictServerHandler<HandleTokenRequestC
         var email = context.Request.Username;
         var password = context.Request.Password;
 
-        if (string.IsNullOrEmpty(email) || string.IsNullOrEmpty(password))
-        {
-            context.Reject(OpenIddictConstants.Errors.InvalidGrant,
-                "The username or password cannot be empty.");
-            return;
-        }
-
         var user = await _userAuthenticationService.ValidateCredentialsAsync(email, password);
         if (user is null)
         {
             context.Reject(OpenIddictConstants.Errors.InvalidGrant,
-                "The username or password is invalid.");
+                "Invalid username or password.");
             return;
         }
 


### PR DESCRIPTION
## Summary
- Drop direct empty credential checks in password grant handler and rely on validation service
- Provide single 'Invalid username or password' message for failed authentication

## Testing
- `dotnet test -c Release` *(fails: command not found: dotnet)*
- `curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh` *(fails: CONNECT tunnel failed, response 403)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af579500008327bc2cb457e2348ad0