### PR TITLE
Use constant for device ID claim

### DIFF
--- a/api/Avancira.API.Tests/ClientInfoServiceTests.cs
+++ b/api/Avancira.API.Tests/ClientInfoServiceTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Hosting;
 using UAParser;
 using Xunit;
 using Moq;
+using Avancira.Infrastructure.Auth;
 
 public class ClientInfoServiceTests
 {
@@ -29,7 +30,7 @@ public class ClientInfoServiceTests
         await service.GetClientInfoAsync();
 
         var cookie = context.Response.Headers["Set-Cookie"].ToString().ToLowerInvariant();
-        cookie.Should().Contain("device_id=");
+        cookie.Should().Contain($"{AuthConstants.Claims.DeviceId}=");
         cookie.Should().NotContain("secure");
     }
 }

--- a/api/Avancira.Infrastructure/Auth/AuthConstants.cs
+++ b/api/Avancira.Infrastructure/Auth/AuthConstants.cs
@@ -28,6 +28,7 @@ public static class AuthConstants
     public static class Claims
     {
         public const string SessionId = "sid";
+        public const string DeviceId = "device_id";
     }
 
     public static class GrantTypes

--- a/api/Avancira.Infrastructure/Common/ClientInfoService.cs
+++ b/api/Avancira.Infrastructure/Common/ClientInfoService.cs
@@ -1,6 +1,7 @@
 using Avancira.Application.Common;
 using Avancira.Application.Catalog;
 using Avancira.Infrastructure.Common.Extensions;
+using Avancira.Infrastructure.Auth;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
 using UAParser;
@@ -31,11 +32,11 @@ public class ClientInfoService : IClientInfoService
     {
         var context = _httpContextAccessor.HttpContext ?? throw new InvalidOperationException("No HttpContext available");
 
-        var deviceId = context.Request.Cookies["device_id"];
+        var deviceId = context.Request.Cookies[AuthConstants.Claims.DeviceId];
         if (string.IsNullOrEmpty(deviceId))
         {
             deviceId = Guid.NewGuid().ToString();
-            context.Response.Cookies.Append("device_id", deviceId, new CookieOptions
+            context.Response.Cookies.Append(AuthConstants.Claims.DeviceId, deviceId, new CookieOptions
             {
                 HttpOnly = true,
                 Secure = !_environment.IsDevelopment(),

--- a/api/Avancira.Infrastructure/Identity/DeviceInfoClaimsHandler.cs
+++ b/api/Avancira.Infrastructure/Identity/DeviceInfoClaimsHandler.cs
@@ -1,6 +1,7 @@
 using OpenIddict.Abstractions;
 using OpenIddict.Server;
 using static OpenIddict.Server.OpenIddictServerEvents;
+using Avancira.Infrastructure.Auth;
 
 namespace Avancira.Infrastructure.Identity;
 
@@ -14,11 +15,11 @@ public class DeviceInfoClaimsHandler : IOpenIddictServerHandler<ProcessSignInCon
             return ValueTask.CompletedTask;
         }
 
-        var deviceId = (string?)request["device_id"];
+        var deviceId = (string?)request[AuthConstants.Claims.DeviceId];
 
         if (!string.IsNullOrEmpty(deviceId))
         {
-            context.Principal.SetClaim("device_id", deviceId);
+            context.Principal.SetClaim(AuthConstants.Claims.DeviceId, deviceId);
         }
 
         return ValueTask.CompletedTask;


### PR DESCRIPTION
## Summary
- add DeviceId claim constant
- use AuthConstants.Claims.DeviceId for device ID interactions

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden on package repository)*

------
https://chatgpt.com/codex/tasks/task_e_68af57ac44cc8327839f63cc78aa3dee