### PR TITLE
Handle token endpoint errors

### DIFF
--- a/api/Avancira.API.Tests/AuthenticationServiceTests.cs
+++ b/api/Avancira.API.Tests/AuthenticationServiceTests.cs
@@ -64,12 +64,14 @@ public class AuthenticationServiceTests
     public async Task GenerateTokenAsync_NonSuccessResponse_ThrowsTokenRequestException()
     {
         var clientInfoService = new StubClientInfoService(new ClientInfo());
-        var tokenClient = new StubTokenEndpointClient(new TokenRequestException(System.Net.HttpStatusCode.BadRequest));
+        var tokenClient = new StubTokenEndpointClient(new TokenRequestException("invalid_request", "bad request", System.Net.HttpStatusCode.BadRequest));
         var sessionService = new Mock<ISessionService>().Object;
         var service = new AuthenticationService(clientInfoService, tokenClient, sessionService);
 
         var ex = await Assert.ThrowsAsync<TokenRequestException>(() => service.GenerateTokenAsync("user1"));
         ex.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+        ex.Error.Should().Be("invalid_request");
+        ex.ErrorDescription.Should().Be("bad request");
     }
 
     [Fact]

--- a/api/Avancira.Domain/Common/Exceptions/TokenRequestException.cs
+++ b/api/Avancira.Domain/Common/Exceptions/TokenRequestException.cs
@@ -5,14 +5,24 @@ namespace Avancira.Domain.Common.Exceptions;
 
 public class TokenRequestException : AvanciraException
 {
+    public string? Error { get; }
+    public string? ErrorDescription { get; }
+
     public TokenRequestException(HttpStatusCode statusCode)
-        : base("token request failed", new Collection<string>(), statusCode)
+        : this(null, null, statusCode)
     {
     }
 
     public TokenRequestException(string message, HttpStatusCode statusCode)
-        : base(message, new Collection<string>(), statusCode)
+        : this(null, message, statusCode)
     {
+    }
+
+    public TokenRequestException(string? error, string? errorDescription, HttpStatusCode statusCode)
+        : base(errorDescription ?? "token request failed", new Collection<string>(), statusCode)
+    {
+        Error = error;
+        ErrorDescription = errorDescription;
     }
 }
 

--- a/api/Avancira.Infrastructure/Auth/TokenEndpointClient.cs
+++ b/api/Avancira.Infrastructure/Auth/TokenEndpointClient.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Json;
 using Avancira.Application.Identity.Tokens.Dtos;
 using Avancira.Domain.Common.Exceptions;
 
@@ -28,7 +29,8 @@ public class TokenEndpointClient : ITokenEndpointClient
 
         if (!response.IsSuccessStatusCode)
         {
-            throw new TokenRequestException(response.StatusCode);
+            var problem = await response.Content.ReadFromJsonAsync<TokenRequestProblemDetails>();
+            throw new TokenRequestException(problem?.Error, problem?.ErrorDescription, response.StatusCode);
         }
 
         await using var stream = await response.Content.ReadAsStreamAsync();

--- a/api/Avancira.Infrastructure/Auth/TokenRequestProblemDetails.cs
+++ b/api/Avancira.Infrastructure/Auth/TokenRequestProblemDetails.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace Avancira.Infrastructure.Auth;
+
+public class TokenRequestProblemDetails
+{
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("error_description")]
+    public string? ErrorDescription { get; set; }
+}
+

--- a/api/Avancira.Infrastructure/Exceptions/CustomExceptionHandler.cs
+++ b/api/Avancira.Infrastructure/Exceptions/CustomExceptionHandler.cs
@@ -28,6 +28,20 @@ public class CustomExceptionHandler(ILogger<CustomExceptionHandler> logger) : IE
             problemDetails.Extensions.Add("errors", validationErrors);
         }
 
+        else if (exception is TokenRequestException tokenEx)
+        {
+            httpContext.Response.StatusCode = (int)tokenEx.StatusCode;
+            problemDetails.Detail = tokenEx.ErrorDescription ?? tokenEx.Message;
+            if (!string.IsNullOrEmpty(tokenEx.Error))
+            {
+                problemDetails.Extensions.Add("error", tokenEx.Error);
+            }
+            if (!string.IsNullOrEmpty(tokenEx.ErrorDescription))
+            {
+                problemDetails.Extensions.Add("error_description", tokenEx.ErrorDescription);
+            }
+        }
+
         else if (exception is AvanciraException e)
         {
             httpContext.Response.StatusCode = (int)e.StatusCode;


### PR DESCRIPTION
## Summary
- parse token endpoint error responses and include details in TokenRequestException
- map TokenRequestException to ProblemDetails with error fields
- cover token request failures in tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68af69e2bda483278fd5003549156d67