### PR TITLE
Add logging and scope validation for password grant handler

### DIFF
--- a/api/Avancira.API.Tests/PasswordGrantHandlerTests.cs
+++ b/api/Avancira.API.Tests/PasswordGrantHandlerTests.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using System.Security.Claims;
+using Avancira.Application.Identity;
+using Avancira.Infrastructure.Identity;
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Moq;
+using OpenIddict.Abstractions;
+using OpenIddict.Server;
+using Xunit;
+using static OpenIddict.Server.OpenIddictServerEvents;
+
+public class PasswordGrantHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_ValidRequest_SetsPrincipalAndHandles()
+    {
+        var user = new IdentityUser();
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+
+        var authService = new Mock<IUserAuthenticationService>();
+        authService.Setup(x => x.ValidateCredentialsAsync("test@example.com", "pwd"))
+            .ReturnsAsync(user);
+        authService.Setup(x => x.CreatePrincipalAsync(user)).ReturnsAsync(principal);
+
+        var logger = new TestLogger<PasswordGrantHandler>();
+        var handler = new PasswordGrantHandler(authService.Object, logger);
+
+        var request = new OpenIddictRequest
+        {
+            GrantType = OpenIddictConstants.GrantTypes.Password,
+            Username = "test@example.com",
+            Password = "pwd",
+            Scope = "openid profile"
+        };
+        var transaction = new OpenIddictServerTransaction
+        {
+            Request = request
+        };
+        var context = new HandleTokenRequestContext(transaction);
+
+        await handler.HandleAsync(context);
+
+        context.Principal.Should().Be(principal);
+        context.IsHandled.Should().BeTrue();
+        logger.Logs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_InvalidCredentials_LogsWarningAndRejects()
+    {
+        var authService = new Mock<IUserAuthenticationService>();
+        authService.Setup(x => x.ValidateCredentialsAsync("user", "bad"))
+            .ReturnsAsync((IdentityUser?)null);
+
+        var logger = new TestLogger<PasswordGrantHandler>();
+        var handler = new PasswordGrantHandler(authService.Object, logger);
+
+        var request = new OpenIddictRequest
+        {
+            GrantType = OpenIddictConstants.GrantTypes.Password,
+            Username = "user",
+            Password = "bad",
+            Scope = "openid"
+        };
+        var transaction = new OpenIddictServerTransaction
+        {
+            Request = request
+        };
+        var context = new HandleTokenRequestContext(transaction);
+
+        await handler.HandleAsync(context);
+
+        context.IsRejected.Should().BeTrue();
+        context.Error.Should().Be(OpenIddictConstants.Errors.InvalidGrant);
+        logger.Logs.Should().Contain(x => x.LogLevel == LogLevel.Warning && x.Message.Contains("Invalid credentials"));
+    }
+
+    [Fact]
+    public async Task HandleAsync_MissingScope_LogsWarningAndRejects()
+    {
+        var authService = new Mock<IUserAuthenticationService>();
+        var logger = new TestLogger<PasswordGrantHandler>();
+        var handler = new PasswordGrantHandler(authService.Object, logger);
+
+        var request = new OpenIddictRequest
+        {
+            GrantType = OpenIddictConstants.GrantTypes.Password,
+            Username = "user",
+            Password = "pwd"
+        };
+        var transaction = new OpenIddictServerTransaction
+        {
+            Request = request
+        };
+        var context = new HandleTokenRequestContext(transaction);
+
+        await handler.HandleAsync(context);
+
+        context.IsRejected.Should().BeTrue();
+        context.Error.Should().Be(OpenIddictConstants.Errors.InvalidRequest);
+        logger.Logs.Should().Contain(x => x.LogLevel == LogLevel.Warning && x.Message.Contains("scope"));
+    }
+
+    private class TestLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel LogLevel, string Message)> Logs { get; } = new();
+        public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Logs.Add((logLevel, formatter(state, exception)));
+        private class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/api/Avancira.Infrastructure/Identity/PasswordGrantHandler.cs
+++ b/api/Avancira.Infrastructure/Identity/PasswordGrantHandler.cs
@@ -1,6 +1,7 @@
 using OpenIddict.Abstractions;
 using OpenIddict.Server;
 using Avancira.Application.Identity;
+using Microsoft.Extensions.Logging;
 using static OpenIddict.Server.OpenIddictServerEvents;
 
 namespace Avancira.Infrastructure.Identity;
@@ -8,9 +9,15 @@ namespace Avancira.Infrastructure.Identity;
 public class PasswordGrantHandler : IOpenIddictServerHandler<HandleTokenRequestContext>
 {
     private readonly IUserAuthenticationService _userAuthenticationService;
+    private readonly ILogger<PasswordGrantHandler> _logger;
 
-    public PasswordGrantHandler(IUserAuthenticationService userAuthenticationService)
-        => _userAuthenticationService = userAuthenticationService;
+    public PasswordGrantHandler(
+        IUserAuthenticationService userAuthenticationService,
+        ILogger<PasswordGrantHandler> logger)
+    {
+        _userAuthenticationService = userAuthenticationService;
+        _logger = logger;
+    }
 
     public async ValueTask HandleAsync(HandleTokenRequestContext context)
     {
@@ -19,11 +26,29 @@ public class PasswordGrantHandler : IOpenIddictServerHandler<HandleTokenRequestC
             return;
         }
 
+        if (string.IsNullOrEmpty(context.Request.Scope))
+        {
+            _logger.LogWarning("Token request missing scope parameter.");
+            context.Reject(OpenIddictConstants.Errors.InvalidRequest,
+                "The 'scope' parameter is required.");
+            return;
+        }
+
+        var scopes = context.Request.GetScopes();
+        if (!scopes.Contains(OpenIddictConstants.Scopes.OpenId))
+        {
+            _logger.LogWarning("Token request missing required 'openid' scope.");
+            context.Reject(OpenIddictConstants.Errors.InvalidScope,
+                "The required 'openid' scope is missing.");
+            return;
+        }
+
         var email = context.Request.Username;
         var password = context.Request.Password;
 
         if (string.IsNullOrEmpty(email) || string.IsNullOrEmpty(password))
         {
+            _logger.LogWarning("Token request missing username or password.");
             context.Reject(OpenIddictConstants.Errors.InvalidGrant,
                 "The username or password cannot be empty.");
             return;
@@ -32,13 +57,14 @@ public class PasswordGrantHandler : IOpenIddictServerHandler<HandleTokenRequestC
         var user = await _userAuthenticationService.ValidateCredentialsAsync(email, password);
         if (user is null)
         {
+            _logger.LogWarning("Invalid credentials for user {Email}.", email);
             context.Reject(OpenIddictConstants.Errors.InvalidGrant,
                 "The username or password is invalid.");
             return;
         }
 
         var principal = await _userAuthenticationService.CreatePrincipalAsync(user);
-        principal.SetScopes(context.Request.GetScopes());
+        principal.SetScopes(scopes);
 
         context.Principal = principal;
         context.HandleRequest();


### PR DESCRIPTION
## Summary
- add detailed logging and scope validation to `PasswordGrantHandler`
- ensure grant handler rejects missing or invalid scope requests
- test successful and failure paths including logging for invalid credentials

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6b0cf9d483279f46987afb46b283