### PR TITLE
Include session ID claim in tokens and link to stored sessions

### DIFF
--- a/api/Avancira.Application/Identity/Tokens/ISessionService.cs
+++ b/api/Avancira.Application/Identity/Tokens/ISessionService.cs
@@ -14,5 +14,5 @@ public interface ISessionService
     Task<bool> ValidateSessionAsync(string userId, Guid sessionId);
     Task<(string UserId, Guid RefreshTokenId)?> GetRefreshTokenInfoAsync(string tokenHash);
     Task RotateRefreshTokenAsync(Guid refreshTokenId, string newRefreshTokenHash, DateTime newExpiry);
-    Task StoreSessionAsync(string userId, ClientInfo clientInfo, string refreshToken, DateTime refreshExpiry);
+    Task StoreSessionAsync(string userId, Guid sessionId, ClientInfo clientInfo, string refreshToken, DateTime refreshExpiry);
 }

--- a/api/Avancira.Domain/Identity/Session.cs
+++ b/api/Avancira.Domain/Identity/Session.cs
@@ -10,6 +10,11 @@ public class Session : BaseEntity<Guid>, IAggregateRoot
         RefreshTokens = new List<RefreshToken>();
     }
 
+    public Session(Guid id) : this()
+    {
+        Id = id;
+    }
+
     public string UserId { get; set; } = default!;
     public string Device { get; set; } = default!;
     public string? UserAgent { get; set; }

--- a/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
+++ b/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
@@ -39,6 +39,8 @@ public static class OpenIddictSetup
                     builder.UseScopedHandler<ExternalLoginHandler>());
                 options.AddEventHandler<ProcessSignInContext>(builder =>
                     builder.UseScopedHandler<DeviceInfoClaimsHandler>());
+                options.AddEventHandler<ProcessSignInContext>(builder =>
+                    builder.UseScopedHandler<SessionIdClaimsHandler>());
                 options.AddEventHandler<HandleTokenRequestContext>(builder =>
                     builder.UseScopedHandler<PasswordGrantHandler>());
             })

--- a/api/Avancira.Infrastructure/Identity/SessionIdClaimsHandler.cs
+++ b/api/Avancira.Infrastructure/Identity/SessionIdClaimsHandler.cs
@@ -1,0 +1,26 @@
+using OpenIddict.Abstractions;
+using OpenIddict.Server;
+using static OpenIddict.Server.OpenIddictServerEvents;
+using Avancira.Infrastructure.Auth;
+using System;
+
+namespace Avancira.Infrastructure.Identity;
+
+public class SessionIdClaimsHandler : IOpenIddictServerHandler<ProcessSignInContext>
+{
+    public ValueTask HandleAsync(ProcessSignInContext context)
+    {
+        if (context.Principal is null)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        var existing = context.Principal.GetClaim(AuthConstants.Claims.SessionId);
+        if (string.IsNullOrEmpty(existing))
+        {
+            context.Principal.SetClaim(AuthConstants.Claims.SessionId, Guid.NewGuid().ToString(), OpenIddictConstants.Destinations.AccessToken);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/api/Avancira.Infrastructure/Identity/Tokens/SessionService.cs
+++ b/api/Avancira.Infrastructure/Identity/Tokens/SessionService.cs
@@ -21,7 +21,7 @@ public class SessionService : ISessionService
         _dbContext = dbContext;
     }
 
-    public async Task StoreSessionAsync(string userId, ClientInfo clientInfo, string refreshToken, DateTime refreshExpiry)
+    public async Task StoreSessionAsync(string userId, Guid sessionId, ClientInfo clientInfo, string refreshToken, DateTime refreshExpiry)
     {
         var existingSession = await _dbContext.Sessions
             .Include(s => s.RefreshTokens)
@@ -35,7 +35,7 @@ public class SessionService : ISessionService
         }
 
         var now = DateTime.UtcNow;
-        var session = new Session
+        var session = new Session(sessionId)
         {
             UserId = userId,
             Device = clientInfo.DeviceId,


### PR DESCRIPTION
## Summary
- generate a `sid` claim during sign-in and register a handler so tokens carry the session id
- store sessions using the token's `sid` so JWT validation can reference the same id
- update authentication and session services plus tests to handle session ids

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68af6ef1aa54832791e58be0b099db9d