### PR TITLE
refactor: centralize password grant constant

### DIFF
--- a/admin/Infrastructure/Api/ApiClient.cs
+++ b/admin/Infrastructure/Api/ApiClient.cs
@@ -6414,7 +6414,7 @@ namespace Avancira.Admin.Infrastructure.Api
     public partial class ChangePasswordDto
     {
 
-        [System.Text.Json.Serialization.JsonPropertyName("password")]
+        [System.Text.Json.Serialization.JsonPropertyName(global::Avancira.Infrastructure.Auth.AuthConstants.GrantTypes.Password)]
         public string? Password { get; set; } = default!;
 
         [System.Text.Json.Serialization.JsonPropertyName("newPassword")]
@@ -6787,7 +6787,7 @@ namespace Avancira.Admin.Infrastructure.Api
         [System.Text.Json.Serialization.JsonPropertyName("email")]
         public string? Email { get; set; } = default!;
 
-        [System.Text.Json.Serialization.JsonPropertyName("password")]
+        [System.Text.Json.Serialization.JsonPropertyName(global::Avancira.Infrastructure.Auth.AuthConstants.GrantTypes.Password)]
         public string? Password { get; set; } = default!;
 
     }
@@ -6959,7 +6959,7 @@ namespace Avancira.Admin.Infrastructure.Api
         [System.Text.Json.Serialization.JsonPropertyName("userName")]
         public string? UserName { get; set; } = default!;
 
-        [System.Text.Json.Serialization.JsonPropertyName("password")]
+        [System.Text.Json.Serialization.JsonPropertyName(global::Avancira.Infrastructure.Auth.AuthConstants.GrantTypes.Password)]
         public string? Password { get; set; } = default!;
 
         [System.Text.Json.Serialization.JsonPropertyName("confirmPassword")]
@@ -6986,7 +6986,7 @@ namespace Avancira.Admin.Infrastructure.Api
         [System.Text.Json.Serialization.JsonPropertyName("email")]
         public string? Email { get; set; } = default!;
 
-        [System.Text.Json.Serialization.JsonPropertyName("password")]
+        [System.Text.Json.Serialization.JsonPropertyName(global::Avancira.Infrastructure.Auth.AuthConstants.GrantTypes.Password)]
         public string? Password { get; set; } = default!;
 
         [System.Text.Json.Serialization.JsonPropertyName("token")]
@@ -7131,7 +7131,7 @@ namespace Avancira.Admin.Infrastructure.Api
         [System.Text.Json.Serialization.JsonPropertyName("email")]
         public string? Email { get; set; } = default!;
 
-        [System.Text.Json.Serialization.JsonPropertyName("password")]
+        [System.Text.Json.Serialization.JsonPropertyName(global::Avancira.Infrastructure.Auth.AuthConstants.GrantTypes.Password)]
         public string? Password { get; set; } = default!;
 
     }

--- a/admin/Infrastructure/Infrastructure.csproj
+++ b/admin/Infrastructure/Infrastructure.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\api\Avancira.Shared\Avancira.Shared.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
+    <ProjectReference Include="..\..\api\Avancira.Infrastructure\Avancira.Infrastructure.csproj" />
   </ItemGroup>
 
   <Target Name="NSwag">

--- a/api/Avancira.Infrastructure/Auth/AuthConstants.cs
+++ b/api/Avancira.Infrastructure/Auth/AuthConstants.cs
@@ -36,6 +36,7 @@ public static class AuthConstants
         public const string AuthorizationCode = "authorization_code";
         public const string UserId = "user_id";
         public const string RefreshToken = "refresh_token";
+        public const string Password = "password";
     }
 
     public static class Cookies

--- a/api/Avancira.Migrations/AvanciraDbContextFactory.cs
+++ b/api/Avancira.Migrations/AvanciraDbContextFactory.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Avancira.Application.Persistence;
 using MediatR;
+using Avancira.Infrastructure.Auth;
 using Moq;
 
 namespace Avancira.Migrations
@@ -20,7 +21,7 @@ namespace Avancira.Migrations
             var port = Environment.GetEnvironmentVariable("Avancira__Database__Port") ?? "5432";
             var database = Environment.GetEnvironmentVariable("Avancira__Database__Name") ?? "AvanciraDb";
             var username = Environment.GetEnvironmentVariable("Avancira__Database__User") ?? "postgres";
-            var password = Environment.GetEnvironmentVariable("Avancira__Database__Password") ?? "password";
+            var password = Environment.GetEnvironmentVariable("Avancira__Database__Password") ?? AuthConstants.GrantTypes.Password;
 
             var connectionString = $"Host={host};Port={port};Database={database};Username={username};Password={password}";
 


### PR DESCRIPTION
## Summary
- add password grant type constant
- replace hard-coded "password" occurrences with AuthConstants.GrantTypes.Password

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68af720dbe448327ac260a9662e118ab