### PR TITLE
Use DTO to parse token response with JsonSerializer

### DIFF
--- a/api/Avancira.Infrastructure/Auth/TokenResponseParser.cs
+++ b/api/Avancira.Infrastructure/Auth/TokenResponseParser.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Avancira.Application.Auth.Jwt;
 using Avancira.Application.Identity.Tokens.Dtos;
 using Microsoft.Extensions.Options;
@@ -15,23 +16,28 @@ public class TokenResponseParser : ITokenResponseParser
 
     public async Task<TokenPair> ParseAsync(Stream stream)
     {
-        using var document = await JsonDocument.ParseAsync(stream);
-        var root = document.RootElement;
+        var response = await JsonSerializer.DeserializeAsync<InternalTokenResponse>(stream);
 
-        var token = root.GetProperty(AuthConstants.Parameters.AccessToken).GetString() ?? string.Empty;
-        var refresh = root.GetProperty(AuthConstants.Parameters.RefreshToken).GetString() ?? string.Empty;
+        var token = response?.AccessToken ?? string.Empty;
+        var refresh = response?.RefreshToken ?? string.Empty;
 
-        DateTime refreshExpiry;
-        if (root.TryGetProperty(AuthConstants.Parameters.RefreshTokenExpiresIn, out var exp))
-        {
-            refreshExpiry = DateTime.UtcNow.AddSeconds(exp.GetInt32());
-        }
-        else
-        {
-            refreshExpiry = DateTime.UtcNow.AddDays(_jwtOptions.RefreshTokenDefaultDays);
-        }
+        var refreshExpiry = response?.RefreshTokenExpiresIn is int expiresIn
+            ? DateTime.UtcNow.AddSeconds(expiresIn)
+            : DateTime.UtcNow.AddDays(_jwtOptions.RefreshTokenDefaultDays);
 
         return new TokenPair(token, refresh, refreshExpiry);
+    }
+
+    private class InternalTokenResponse
+    {
+        [JsonPropertyName(AuthConstants.Parameters.AccessToken)]
+        public string? AccessToken { get; set; }
+
+        [JsonPropertyName(AuthConstants.Parameters.RefreshToken)]
+        public string? RefreshToken { get; set; }
+
+        [JsonPropertyName(AuthConstants.Parameters.RefreshTokenExpiresIn)]
+        public int? RefreshTokenExpiresIn { get; set; }
     }
 }
 


### PR DESCRIPTION
## Summary
- parse token responses via JsonSerializer with a dedicated DTO
- default refresh token expiry when `refresh_token_expires_in` is missing

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68af7251d9f48327aa77a3697d66c5f2