### PR TITLE
Use HMAC with configurable secret for token hashing

### DIFF
--- a/api/Avancira.API.Tests/TokenUtilitiesTests.cs
+++ b/api/Avancira.API.Tests/TokenUtilitiesTests.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Avancira.Infrastructure.Auth;
+using FluentAssertions;
+using Xunit;
+
+public class TokenUtilitiesTests
+{
+    [Fact]
+    public void HashToken_WithDifferentSalts_ProducesDifferentHashes()
+    {
+        var token = "token";
+        var secret = "secret";
+        var salt1 = RandomNumberGenerator.GetBytes(16);
+        var salt2 = RandomNumberGenerator.GetBytes(16);
+
+        var hash1 = TokenUtilities.HashToken(token, secret, salt1);
+        var hash2 = TokenUtilities.HashToken(token, secret, salt2);
+
+        hash1.Should().NotBe(hash2);
+    }
+
+    [Fact]
+    public void HashToken_WithHmac_ProducesExpectedHash()
+    {
+        var token = "token";
+        var secret = "secret";
+        var salt = Encoding.UTF8.GetBytes("salt");
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        var expected = Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(token).Concat(salt).ToArray()));
+
+        TokenUtilities.HashToken(token, secret, salt).Should().Be(expected);
+    }
+}

--- a/api/Avancira.Infrastructure/Auth/TokenHashingOptions.cs
+++ b/api/Avancira.Infrastructure/Auth/TokenHashingOptions.cs
@@ -1,0 +1,7 @@
+namespace Avancira.Infrastructure.Auth;
+
+public class TokenHashingOptions
+{
+    public string Secret { get; set; } = string.Empty;
+}
+

--- a/api/Avancira.Infrastructure/Auth/TokenUtilities.cs
+++ b/api/Avancira.Infrastructure/Auth/TokenUtilities.cs
@@ -5,11 +5,18 @@ namespace Avancira.Infrastructure.Auth;
 
 public static class TokenUtilities
 {
-    public static string HashToken(string token)
+    public static string HashToken(string token, string secret, byte[]? salt = null)
     {
-        using var sha = SHA256.Create();
-        var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(token));
-        return Convert.ToBase64String(bytes);
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        var tokenBytes = Encoding.UTF8.GetBytes(token);
+        if (salt is { Length: > 0 })
+        {
+            var combined = new byte[tokenBytes.Length + salt.Length];
+            Buffer.BlockCopy(tokenBytes, 0, combined, 0, tokenBytes.Length);
+            Buffer.BlockCopy(salt, 0, combined, tokenBytes.Length, salt.Length);
+            tokenBytes = combined;
+        }
+        var hash = hmac.ComputeHash(tokenBytes);
+        return Convert.ToBase64String(hash);
     }
 }
-

--- a/api/Avancira.Infrastructure/Extensions.cs
+++ b/api/Avancira.Infrastructure/Extensions.cs
@@ -75,6 +75,7 @@ public static class Extensions
         builder.Services.Configure<JitsiOptions>(builder.Configuration.GetSection("Avancira:Jitsi"));
         builder.Services.Configure<GoogleOptions>(builder.Configuration.GetSection("Avancira:ExternalServices:Google"));
         builder.Services.Configure<FacebookOptions>(builder.Configuration.GetSection("Avancira:ExternalServices:Facebook"));
+        builder.Services.Configure<TokenHashingOptions>(builder.Configuration.GetSection("Avancira:Auth:TokenHashing"));
 
 
         // Configure Mappings

--- a/api/Avancira.Infrastructure/Identity/Tokens/SessionService.cs
+++ b/api/Avancira.Infrastructure/Identity/Tokens/SessionService.cs
@@ -9,16 +9,19 @@ using System.Collections.Generic;
 using System.Linq;
 using Mapster;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace Avancira.Infrastructure.Identity.Tokens;
 
 public class SessionService : ISessionService
 {
     private readonly AvanciraDbContext _dbContext;
+    private readonly TokenHashingOptions _options;
 
-    public SessionService(AvanciraDbContext dbContext)
+    public SessionService(AvanciraDbContext dbContext, IOptions<TokenHashingOptions> options)
     {
         _dbContext = dbContext;
+        _options = options.Value;
     }
 
     public async Task StoreSessionAsync(string userId, Guid sessionId, ClientInfo clientInfo, string refreshToken, DateTime refreshExpiry)
@@ -52,7 +55,7 @@ public class SessionService : ISessionService
 
         session.RefreshTokens.Add(new RefreshToken
         {
-            TokenHash = TokenUtilities.HashToken(refreshToken),
+            TokenHash = TokenUtilities.HashToken(refreshToken, _options.Secret),
             CreatedUtc = now,
             AbsoluteExpiryUtc = refreshExpiry
         });


### PR DESCRIPTION
## Summary
- Use HMAC SHA-256 with configurable secret in `TokenUtilities.HashToken`
- Inject token hashing options into services and bind configuration
- Add token hashing unit tests covering salt variation and HMAC correctness

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af76580e508327b777a7f34bc0b84a