### PR TITLE
Make authentication scope configurable

### DIFF
--- a/api/Avancira.API.Tests/AuthenticationServiceTests.cs
+++ b/api/Avancira.API.Tests/AuthenticationServiceTests.cs
@@ -52,7 +52,8 @@ public class AuthenticationServiceTests
         var sessionService = new SessionService(dbContext, hashingOptions);
         var validator = new TokenRequestParamsValidator();
         var jwtOptions = Options.Create(new JwtOptions { Key = JwtKey, Issuer = JwtIssuer, Audience = JwtAudience });
-        var service = new AuthenticationService(clientInfoService, tokenClient, sessionService, validator, hashingOptions, jwtOptions);
+        var scopeOptions = Options.Create(new AuthScopeOptions { Scope = AuthConstants.Scopes.Api });
+        var service = new AuthenticationService(clientInfoService, tokenClient, sessionService, validator, hashingOptions, jwtOptions, scopeOptions);
 
         await service.GenerateTokenAsync(userId);
         var storedToken = await dbContext.RefreshTokens.SingleAsync();
@@ -78,7 +79,8 @@ public class AuthenticationServiceTests
         var validator = new TokenRequestParamsValidator();
         var options = Options.Create(new TokenHashingOptions { Secret = "secret" });
         var jwtOptions = Options.Create(new JwtOptions { Key = JwtKey, Issuer = JwtIssuer, Audience = JwtAudience });
-        var service = new AuthenticationService(clientInfoService, tokenClient, sessionService, validator, options, jwtOptions);
+        var scopeOptions = Options.Create(new AuthScopeOptions { Scope = AuthConstants.Scopes.Api });
+        var service = new AuthenticationService(clientInfoService, tokenClient, sessionService, validator, options, jwtOptions, scopeOptions);
 
         await Assert.ThrowsAsync<UnauthorizedException>(() => service.GenerateTokenAsync("user1"));
     }
@@ -92,7 +94,8 @@ public class AuthenticationServiceTests
         var validator = new TokenRequestParamsValidator();
         var options = Options.Create(new TokenHashingOptions { Secret = "secret" });
         var jwtOptions = Options.Create(new JwtOptions { Key = JwtKey, Issuer = JwtIssuer, Audience = JwtAudience });
-        var service = new AuthenticationService(clientInfoService, tokenClient, sessionService, validator, options, jwtOptions);
+        var scopeOptions = Options.Create(new AuthScopeOptions { Scope = AuthConstants.Scopes.Api });
+        var service = new AuthenticationService(clientInfoService, tokenClient, sessionService, validator, options, jwtOptions, scopeOptions);
 
         var ex = await Assert.ThrowsAsync<TokenRequestException>(() => service.GenerateTokenAsync("user1"));
         ex.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
@@ -149,7 +152,8 @@ public class AuthenticationServiceTests
         var validator = new TokenRequestParamsValidator();
         var hashingOptions = Options.Create(new TokenHashingOptions { Secret = "secret" });
         var jwtOptions = Options.Create(new JwtOptions { Key = JwtKey, Issuer = JwtIssuer, Audience = JwtAudience });
-        var service = new AuthenticationService(clientInfoService, tokenClient, sessionService, validator, hashingOptions, jwtOptions);
+        var scopeOptions = Options.Create(new AuthScopeOptions { Scope = AuthConstants.Scopes.Api });
+        var service = new AuthenticationService(clientInfoService, tokenClient, sessionService, validator, hashingOptions, jwtOptions, scopeOptions);
 
         await Assert.ThrowsAsync<SecurityTokenException>(() => service.GenerateTokenAsync("user1"));
     }
@@ -166,7 +170,8 @@ public class AuthenticationServiceTests
         var validator = new TokenRequestParamsValidator();
         var hashingOptions = Options.Create(new TokenHashingOptions { Secret = "secret" });
         var jwtOptions = Options.Create(new JwtOptions { Key = JwtKey, Issuer = JwtIssuer, Audience = JwtAudience });
-        var service = new AuthenticationService(clientInfoService, tokenClient, sessionService, validator, hashingOptions, jwtOptions);
+        var scopeOptions = Options.Create(new AuthScopeOptions { Scope = AuthConstants.Scopes.Api });
+        var service = new AuthenticationService(clientInfoService, tokenClient, sessionService, validator, hashingOptions, jwtOptions, scopeOptions);
 
         await Assert.ThrowsAsync<SecurityTokenException>(() => service.GenerateTokenAsync("user1"));
     }

--- a/api/Avancira.API.Tests/TokenEndpointClientTests.cs
+++ b/api/Avancira.API.Tests/TokenEndpointClientTests.cs
@@ -36,7 +36,7 @@ public class TokenEndpointClientTests
         {
             GrantType = AuthConstants.GrantTypes.UserId,
             UserId = "user1",
-            Scope = "api offline_access"
+            Scope = AuthConstants.Scopes.Api
         };
         var pair = await client.RequestTokenAsync(parameters);
 
@@ -58,7 +58,7 @@ public class TokenEndpointClientTests
         {
             GrantType = AuthConstants.GrantTypes.UserId,
             UserId = "u",
-            Scope = "api offline_access"
+            Scope = AuthConstants.Scopes.Api
         }));
     }
 
@@ -80,7 +80,7 @@ public class TokenEndpointClientTests
         {
             GrantType = AuthConstants.GrantTypes.UserId,
             UserId = "u",
-            Scope = "api offline_access"
+            Scope = AuthConstants.Scopes.Api
         }));
         ex.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         ex.Error.Should().Be("invalid_request");

--- a/api/Avancira.Infrastructure/Auth/AuthConstants.cs
+++ b/api/Avancira.Infrastructure/Auth/AuthConstants.cs
@@ -39,6 +39,11 @@ public static class AuthConstants
         public const string Password = "password";
     }
 
+    public static class Scopes
+    {
+        public const string Api = "api offline_access";
+    }
+
     public static class Cookies
     {
         public const string RefreshToken = "refreshToken";

--- a/api/Avancira.Infrastructure/Auth/AuthScopeOptions.cs
+++ b/api/Avancira.Infrastructure/Auth/AuthScopeOptions.cs
@@ -1,0 +1,7 @@
+namespace Avancira.Infrastructure.Auth;
+
+public class AuthScopeOptions
+{
+    public string Scope { get; set; } = AuthConstants.Scopes.Api;
+}
+

--- a/api/Avancira.Infrastructure/Auth/AuthenticationService.cs
+++ b/api/Avancira.Infrastructure/Auth/AuthenticationService.cs
@@ -21,6 +21,7 @@ public class AuthenticationService : IAuthenticationService
     private readonly IValidator<TokenRequestParams> _validator;
     private readonly TokenHashingOptions _options;
     private readonly JwtOptions _jwtOptions;
+    private readonly string _scope;
 
     public AuthenticationService(
         IClientInfoService clientInfoService,
@@ -28,7 +29,8 @@ public class AuthenticationService : IAuthenticationService
         ISessionService sessionService,
         IValidator<TokenRequestParams> validator,
         IOptions<TokenHashingOptions> options,
-        IOptions<JwtOptions> jwtOptions)
+        IOptions<JwtOptions> jwtOptions,
+        IOptions<AuthScopeOptions> scopeOptions)
     {
         _clientInfoService = clientInfoService;
         _tokenClient = tokenClient;
@@ -36,6 +38,7 @@ public class AuthenticationService : IAuthenticationService
         _validator = validator;
         _options = options.Value;
         _jwtOptions = jwtOptions.Value;
+        _scope = scopeOptions.Value.Scope;
     }
 
     public async Task<TokenPair> ExchangeCodeAsync(string code, string codeVerifier, string redirectUri)
@@ -64,7 +67,7 @@ public class AuthenticationService : IAuthenticationService
         {
             GrantType = AuthConstants.GrantTypes.UserId,
             UserId = userId,
-            Scope = "api offline_access"
+            Scope = _scope
         };
 
         await _validator.ValidateAndThrowAsync(request);


### PR DESCRIPTION
## Summary
- centralize default scope string in `AuthConstants.Scopes`
- inject scope via `AuthScopeOptions` into `AuthenticationService`
- update tests to use configurable scope

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68af7a900c3483279e38fafc846daaeb