### PR TITLE
Store refresh token salt and hash for validation

### DIFF
--- a/api/Avancira.API.Tests/TokenUtilitiesTests.cs
+++ b/api/Avancira.API.Tests/TokenUtilitiesTests.cs
@@ -15,8 +15,8 @@ public class TokenUtilitiesTests
         var salt1 = RandomNumberGenerator.GetBytes(16);
         var salt2 = RandomNumberGenerator.GetBytes(16);
 
-        var hash1 = TokenUtilities.HashToken(token, secret, salt1);
-        var hash2 = TokenUtilities.HashToken(token, secret, salt2);
+        var (_, hash1) = TokenUtilities.HashToken(token, secret, salt1);
+        var (_, hash2) = TokenUtilities.HashToken(token, secret, salt2);
 
         hash1.Should().NotBe(hash2);
     }
@@ -30,6 +30,7 @@ public class TokenUtilitiesTests
         using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
         var expected = Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(token).Concat(salt).ToArray()));
 
-        TokenUtilities.HashToken(token, secret, salt).Should().Be(expected);
+        var (_, hash) = TokenUtilities.HashToken(token, secret, salt);
+        hash.Should().Be(expected);
     }
 }

--- a/api/Avancira.Application/Identity/Tokens/ISessionService.cs
+++ b/api/Avancira.Application/Identity/Tokens/ISessionService.cs
@@ -12,7 +12,7 @@ public interface ISessionService
     Task RevokeSessionAsync(string userId, Guid sessionId);
     Task RevokeSessionsAsync(string userId, IEnumerable<Guid> sessionIds);
     Task<bool> ValidateSessionAsync(string userId, Guid sessionId);
-    Task<(string UserId, Guid RefreshTokenId)?> GetRefreshTokenInfoAsync(string tokenHash);
-    Task RotateRefreshTokenAsync(Guid refreshTokenId, string newRefreshTokenHash, DateTime newExpiry);
+    Task<(string UserId, Guid RefreshTokenId)?> GetRefreshTokenInfoAsync(string refreshToken);
+    Task RotateRefreshTokenAsync(Guid refreshTokenId, string newRefreshTokenHash, byte[] newRefreshTokenSalt, DateTime newExpiry);
     Task StoreSessionAsync(string userId, Guid sessionId, ClientInfo clientInfo, string refreshToken, DateTime refreshExpiry);
 }

--- a/api/Avancira.Domain/Identity/RefreshToken.cs
+++ b/api/Avancira.Domain/Identity/RefreshToken.cs
@@ -5,6 +5,7 @@ using Avancira.Domain.Common;
 public class RefreshToken : BaseEntity<Guid>
 {
     public string TokenHash { get; set; } = default!;
+    public byte[] TokenSalt { get; set; } = default!;
     public Guid SessionId { get; set; }
     public Guid? RotatedFromId { get; set; }
     public DateTime CreatedUtc { get; set; }

--- a/api/Avancira.Infrastructure/Auth/AuthenticationService.cs
+++ b/api/Avancira.Infrastructure/Auth/AuthenticationService.cs
@@ -94,12 +94,11 @@ public class AuthenticationService : IAuthenticationService
 
         return await RequestTokenAsync(request, async (pair, _) =>
         {
-            var oldRefreshHash = TokenUtilities.HashToken(refreshToken, _options.Secret);
-            var info = await _sessionService.GetRefreshTokenInfoAsync(oldRefreshHash);
+            var info = await _sessionService.GetRefreshTokenInfoAsync(refreshToken);
             if (info != null)
             {
-                var newRefreshHash = TokenUtilities.HashToken(pair.RefreshToken, _options.Secret);
-                await _sessionService.RotateRefreshTokenAsync(info.Value.RefreshTokenId, newRefreshHash, pair.RefreshTokenExpiryTime);
+                var (salt, hash) = TokenUtilities.HashToken(pair.RefreshToken, _options.Secret);
+                await _sessionService.RotateRefreshTokenAsync(info.Value.RefreshTokenId, hash, salt, pair.RefreshTokenExpiryTime);
             }
         });
     }

--- a/api/Avancira.Infrastructure/Auth/TokenUtilities.cs
+++ b/api/Avancira.Infrastructure/Auth/TokenUtilities.cs
@@ -5,18 +5,22 @@ namespace Avancira.Infrastructure.Auth;
 
 public static class TokenUtilities
 {
-    public static string HashToken(string token, string secret, byte[]? salt = null)
+    public static (byte[] Salt, string Hash) HashToken(string token, string secret, byte[]? salt = null)
     {
+        salt ??= RandomNumberGenerator.GetBytes(16);
+
         using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
         var tokenBytes = Encoding.UTF8.GetBytes(token);
-        if (salt is { Length: > 0 })
+
+        if (salt.Length > 0)
         {
             var combined = new byte[tokenBytes.Length + salt.Length];
             Buffer.BlockCopy(tokenBytes, 0, combined, 0, tokenBytes.Length);
             Buffer.BlockCopy(salt, 0, combined, tokenBytes.Length, salt.Length);
             tokenBytes = combined;
         }
+
         var hash = hmac.ComputeHash(tokenBytes);
-        return Convert.ToBase64String(hash);
+        return (salt, Convert.ToBase64String(hash));
     }
 }

--- a/api/Avancira.Infrastructure/Identity/Tokens/SessionService.cs
+++ b/api/Avancira.Infrastructure/Identity/Tokens/SessionService.cs
@@ -53,9 +53,11 @@ public class SessionService : ISessionService
             AbsoluteExpiryUtc = refreshExpiry
         };
 
+        var (salt, hash) = TokenUtilities.HashToken(refreshToken, _options.Secret);
         session.RefreshTokens.Add(new RefreshToken
         {
-            TokenHash = TokenUtilities.HashToken(refreshToken, _options.Secret),
+            TokenHash = hash,
+            TokenSalt = salt,
             CreatedUtc = now,
             AbsoluteExpiryUtc = refreshExpiry
         });
@@ -122,21 +124,25 @@ public class SessionService : ISessionService
         await _dbContext.SaveChangesAsync();
     }
 
-    public async Task<(string UserId, Guid RefreshTokenId)?> GetRefreshTokenInfoAsync(string tokenHash)
+    public async Task<(string UserId, Guid RefreshTokenId)?> GetRefreshTokenInfoAsync(string refreshToken)
     {
-        var token = await _dbContext.RefreshTokens
+        var tokens = await _dbContext.RefreshTokens
             .AsNoTracking()
-            .Where(rt => rt.TokenHash == tokenHash && rt.RevokedUtc == null && rt.AbsoluteExpiryUtc > DateTime.UtcNow)
-            .Select(rt => new { rt.Id, rt.Session.UserId })
-            .SingleOrDefaultAsync();
+            .Where(rt => rt.RevokedUtc == null && rt.AbsoluteExpiryUtc > DateTime.UtcNow)
+            .Select(rt => new { rt.Id, rt.Session.UserId, rt.TokenHash, rt.TokenSalt })
+            .ToListAsync();
 
-        if (token == null)
-            return null;
+        foreach (var token in tokens)
+        {
+            var (_, hash) = TokenUtilities.HashToken(refreshToken, _options.Secret, token.TokenSalt);
+            if (hash == token.TokenHash)
+                return (token.UserId, token.Id);
+        }
 
-        return (token.UserId, token.Id);
+        return null;
     }
 
-    public async Task RotateRefreshTokenAsync(Guid refreshTokenId, string newRefreshTokenHash, DateTime newExpiry)
+    public async Task RotateRefreshTokenAsync(Guid refreshTokenId, string newRefreshTokenHash, byte[] newRefreshTokenSalt, DateTime newExpiry)
     {
         var token = await _dbContext.RefreshTokens
             .Include(rt => rt.Session)
@@ -156,6 +162,7 @@ public class SessionService : ISessionService
         session.RefreshTokens.Add(new RefreshToken
         {
             TokenHash = newRefreshTokenHash,
+            TokenSalt = newRefreshTokenSalt,
             CreatedUtc = now,
             AbsoluteExpiryUtc = newExpiry,
             RotatedFromId = token.Id

--- a/api/Avancira.Infrastructure/Persistence/Configurations/SessionConfiguration.cs
+++ b/api/Avancira.Infrastructure/Persistence/Configurations/SessionConfiguration.cs
@@ -44,6 +44,7 @@ public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
             .WithMany(r => r.RefreshTokens)
             .HasForeignKey(r => r.RotatedFromId)
             .OnDelete(DeleteBehavior.Restrict);
+        builder.Property(r => r.TokenSalt).IsRequired();
         builder.HasIndex(r => r.TokenHash);
         builder.HasIndex(r => r.SessionId);
         builder.HasIndex(r => r.RotatedFromId);


### PR DESCRIPTION
## Summary
- return salt and hash from TokenUtilities
- persist refresh-token salt and use it for validation and rotation
- update authentication and tests for salted token hashes

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68af7e05523c8327953a9cb5ddd2e93f