### PR TITLE
Set refresh cookie after post processing

### DIFF
--- a/api/Avancira.Infrastructure/Auth/AuthenticationService.cs
+++ b/api/Avancira.Infrastructure/Auth/AuthenticationService.cs
@@ -119,10 +119,20 @@ public class AuthenticationService : IAuthenticationService
         var updated = parameters with { DeviceId = clientInfo.DeviceId };
 
         var pair = await _tokenClient.RequestTokenAsync(updated);
-        _refreshTokenCookieService.SetRefreshTokenCookie(pair.RefreshToken, pair.RefreshTokenExpiryTime);
-        if (postProcess != null)
+
+        try
         {
-            await postProcess(pair, clientInfo);
+            if (postProcess != null)
+            {
+                await postProcess(pair, clientInfo);
+            }
+
+            _refreshTokenCookieService.SetRefreshTokenCookie(pair.RefreshToken, pair.RefreshTokenExpiryTime);
+        }
+        catch
+        {
+            _refreshTokenCookieService.SetRefreshTokenCookie(string.Empty, DateTime.UtcNow.AddDays(-1));
+            throw;
         }
 
         return pair;


### PR DESCRIPTION
## Summary
- Delay refresh token cookie setting until post-processing completes
- Clear refresh cookie on failure and rethrow

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68af8338ffbc8327911aa74d980cab8d