### PR TITLE
Build token request values conditionally

### DIFF
--- a/api/Avancira.Infrastructure/Auth/TokenRequestBuilder.cs
+++ b/api/Avancira.Infrastructure/Auth/TokenRequestBuilder.cs
@@ -7,11 +7,12 @@ public static class TokenRequestBuilder
 {
     public static FormUrlEncodedContent Build(TokenRequestParams parameters)
     {
-        var values = new Dictionary<string, string?>
-        {
-            [AuthConstants.Parameters.GrantType] = parameters.GrantType
-        };
+        var values = new Dictionary<string, string>();
 
+        if (!string.IsNullOrEmpty(parameters.GrantType))
+        {
+            values[AuthConstants.Parameters.GrantType] = parameters.GrantType;
+        }
         if (!string.IsNullOrEmpty(parameters.Code))
         {
             values[AuthConstants.Parameters.Code] = parameters.Code;
@@ -41,6 +42,6 @@ public static class TokenRequestBuilder
             values[AuthConstants.Parameters.RefreshToken] = parameters.RefreshToken;
         }
 
-        return new FormUrlEncodedContent(values!);
+        return new FormUrlEncodedContent(values);
     }
 }


### PR DESCRIPTION
## Summary
- use `Dictionary<string, string>` in `TokenRequestBuilder`
- add request parameters only when values are provided

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68af86423ba88327a9a42b67a0c77846