### PR TITLE
Ensure session storage is transactional and safe under concurrency

### DIFF
--- a/api/Avancira.API.Tests/SessionServiceTests.cs
+++ b/api/Avancira.API.Tests/SessionServiceTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avancira.Application.Common;
+using Avancira.Infrastructure.Auth;
+using Avancira.Infrastructure.Identity.Tokens;
+using Avancira.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+public class SessionServiceTests
+{
+    [Fact]
+    public async Task StoreSessionAsync_ConcurrentLogins_DoesNotCreateDuplicateSessions()
+    {
+        var options = new DbContextOptionsBuilder<AvanciraDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        var hashingOptions = Options.Create(new TokenHashingOptions { Secret = "secret" });
+        var clientInfo = new ClientInfo
+        {
+            DeviceId = "device1",
+            IpAddress = "127.0.0.1",
+            UserAgent = "agent",
+            OperatingSystem = "os"
+        };
+
+        var barrier = new Barrier(2);
+        var sid1 = Guid.NewGuid();
+        var sid2 = Guid.NewGuid();
+
+        Task RunAsync(Guid sid, string refresh) => Task.Run(async () =>
+        {
+            await using var db = new AvanciraDbContext(options, new Mock<IPublisher>().Object);
+            var service = new SessionService(db, hashingOptions);
+            barrier.SignalAndWait();
+            await service.StoreSessionAsync("user1", sid, clientInfo, refresh, DateTime.UtcNow.AddHours(1));
+        });
+
+        var t1 = RunAsync(sid1, "refresh1");
+        var t2 = RunAsync(sid2, "refresh2");
+        await Task.WhenAll(t1, t2);
+
+        await using var assertionDb = new AvanciraDbContext(options, new Mock<IPublisher>().Object);
+        (await assertionDb.Sessions.CountAsync()).Should().Be(1);
+        (await assertionDb.RefreshTokens.CountAsync()).Should().Be(1);
+        var storedSessionId = (await assertionDb.Sessions.SingleAsync()).Id;
+        storedSessionId.Should().BeOneOf(sid1, sid2);
+    }
+}


### PR DESCRIPTION
## Summary
- Begin transactions before session lookup and repeat removal of pre-existing sessions to avoid duplicate entries
- Add integration test that simulates concurrent logins to verify only one session and refresh token are stored

## Testing
- `dotnet test -c Release` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af879007d88327b4b48d3d6b8fd9b2