### PR TITLE
feat: store salted hashes for refresh tokens

### DIFF
--- a/api/Avancira.API.Tests/TokenUtilitiesTests.cs
+++ b/api/Avancira.API.Tests/TokenUtilitiesTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -12,8 +13,8 @@ public class TokenUtilitiesTests
     {
         var token = "token";
         var secret = "secret";
-        var salt1 = RandomNumberGenerator.GetBytes(16);
-        var salt2 = RandomNumberGenerator.GetBytes(16);
+        var salt1 = TokenUtilities.GenerateSalt();
+        var salt2 = TokenUtilities.GenerateSalt();
 
         var hash1 = TokenUtilities.HashToken(token, secret, salt1);
         var hash2 = TokenUtilities.HashToken(token, secret, salt2);
@@ -26,9 +27,10 @@ public class TokenUtilitiesTests
     {
         var token = "token";
         var secret = "secret";
-        var salt = Encoding.UTF8.GetBytes("salt");
+        var saltBytes = Encoding.UTF8.GetBytes("salt");
+        var salt = Convert.ToBase64String(saltBytes);
         using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
-        var expected = Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(token).Concat(salt).ToArray()));
+        var expected = Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(token).Concat(saltBytes).ToArray()));
 
         TokenUtilities.HashToken(token, secret, salt).Should().Be(expected);
     }

--- a/api/Avancira.Application/Identity/Tokens/ISessionService.cs
+++ b/api/Avancira.Application/Identity/Tokens/ISessionService.cs
@@ -12,7 +12,7 @@ public interface ISessionService
     Task RevokeSessionAsync(string userId, Guid sessionId);
     Task RevokeSessionsAsync(string userId, IEnumerable<Guid> sessionIds);
     Task<bool> ValidateSessionAsync(string userId, Guid sessionId);
-    Task<(string UserId, Guid RefreshTokenId, Guid SessionId)?> GetRefreshTokenInfoAsync(string tokenHash);
-    Task RotateRefreshTokenAsync(Guid refreshTokenId, string newRefreshTokenHash, DateTime newExpiry);
+    Task<(string UserId, Guid RefreshTokenId, Guid SessionId)?> GetRefreshTokenInfoAsync(string refreshToken);
+    Task RotateRefreshTokenAsync(Guid refreshTokenId, string newRefreshToken, DateTime newExpiry);
     Task StoreSessionAsync(string userId, Guid sessionId, ClientInfo clientInfo, string refreshToken, DateTime refreshExpiry);
 }

--- a/api/Avancira.Domain/Identity/RefreshToken.cs
+++ b/api/Avancira.Domain/Identity/RefreshToken.cs
@@ -5,6 +5,7 @@ using Avancira.Domain.Common;
 public class RefreshToken : BaseEntity<Guid>
 {
     public string TokenHash { get; set; } = default!;
+    public string Salt { get; set; } = default!;
     public Guid SessionId { get; set; }
     public Guid? RotatedFromId { get; set; }
     public DateTime CreatedUtc { get; set; }

--- a/api/Avancira.Infrastructure/Auth/AuthenticationService.cs
+++ b/api/Avancira.Infrastructure/Auth/AuthenticationService.cs
@@ -101,12 +101,10 @@ public class AuthenticationService : IAuthenticationService
             var userId = GetUserId(jwt);
             var sessionId = GetSessionId(jwt);
 
-            var oldRefreshHash = TokenUtilities.HashToken(refreshToken, _options.Secret);
-            var info = await _sessionService.GetRefreshTokenInfoAsync(oldRefreshHash);
+            var info = await _sessionService.GetRefreshTokenInfoAsync(refreshToken);
             if (info != null && info.Value.UserId == userId && info.Value.SessionId == sessionId)
             {
-                var newRefreshHash = TokenUtilities.HashToken(pair.RefreshToken, _options.Secret);
-                await _sessionService.RotateRefreshTokenAsync(info.Value.RefreshTokenId, newRefreshHash, pair.RefreshTokenExpiryTime);
+                await _sessionService.RotateRefreshTokenAsync(info.Value.RefreshTokenId, pair.RefreshToken, pair.RefreshTokenExpiryTime);
             }
         });
     }

--- a/api/Avancira.Infrastructure/Auth/TokenUtilities.cs
+++ b/api/Avancira.Infrastructure/Auth/TokenUtilities.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -5,18 +6,21 @@ namespace Avancira.Infrastructure.Auth;
 
 public static class TokenUtilities
 {
-    public static string HashToken(string token, string secret, byte[]? salt = null)
+    public static string GenerateSalt(int size = 16)
+    {
+        var salt = RandomNumberGenerator.GetBytes(size);
+        return Convert.ToBase64String(salt);
+    }
+
+    public static string HashToken(string token, string secret, string salt)
     {
         using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
         var tokenBytes = Encoding.UTF8.GetBytes(token);
-        if (salt is { Length: > 0 })
-        {
-            var combined = new byte[tokenBytes.Length + salt.Length];
-            Buffer.BlockCopy(tokenBytes, 0, combined, 0, tokenBytes.Length);
-            Buffer.BlockCopy(salt, 0, combined, tokenBytes.Length, salt.Length);
-            tokenBytes = combined;
-        }
-        var hash = hmac.ComputeHash(tokenBytes);
+        var saltBytes = Convert.FromBase64String(salt);
+        var combined = new byte[tokenBytes.Length + saltBytes.Length];
+        Buffer.BlockCopy(tokenBytes, 0, combined, 0, tokenBytes.Length);
+        Buffer.BlockCopy(saltBytes, 0, combined, tokenBytes.Length, saltBytes.Length);
+        var hash = hmac.ComputeHash(combined);
         return Convert.ToBase64String(hash);
     }
 }

--- a/api/Avancira.Infrastructure/Persistence/Configurations/SessionConfiguration.cs
+++ b/api/Avancira.Infrastructure/Persistence/Configurations/SessionConfiguration.cs
@@ -36,6 +36,7 @@ public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
     {
         builder.ToTable("RefreshTokens", IdentityConstants.SchemaName);
         builder.HasKey(r => r.Id);
+        builder.Property(r => r.Salt).IsRequired();
         builder.HasOne(r => r.Session)
             .WithMany(s => s.RefreshTokens)
             .HasForeignKey(r => r.SessionId)

--- a/api/Avancira.Migrations/Migrations/20250705000000_AddRefreshTokenSalt.cs
+++ b/api/Avancira.Migrations/Migrations/20250705000000_AddRefreshTokenSalt.cs
@@ -1,0 +1,32 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Avancira.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Avancira.Migrations.Migrations
+{
+    [DbContext(typeof(AvanciraDbContext))]
+    [Migration("20250705000000_AddRefreshTokenSalt")]
+    public class AddRefreshTokenSalt : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Salt",
+                schema: "identity",
+                table: "RefreshTokens",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Salt",
+                schema: "identity",
+                table: "RefreshTokens");
+        }
+    }
+}

--- a/api/Avancira.Migrations/Migrations/AvanciraDbContextModelSnapshot.cs
+++ b/api/Avancira.Migrations/Migrations/AvanciraDbContextModelSnapshot.cs
@@ -97,6 +97,10 @@ namespace Avancira.Migrations.Migrations
                     b.Property<Guid>("SessionId")
                         .HasColumnType("uuid");
 
+                    b.Property<string>("Salt")
+                        .IsRequired()
+                        .HasColumnType("text");
+
                     b.Property<string>("TokenHash")
                         .IsRequired()
                         .HasColumnType("text");


### PR DESCRIPTION
## Summary
- add `Salt` field to refresh tokens and configure EF
- hash refresh tokens with per-token salt and rotate using salt
- expose salt utilities for hashing

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68af878e5cb88327b5be1bc08f133a02