### PR TITLE
Link login page to external providers

### DIFF
--- a/api/Avancira.API/Pages/Account/Login.cshtml
+++ b/api/Avancira.API/Pages/Account/Login.cshtml
@@ -17,11 +17,7 @@
     <button type="submit">Log in</button>
 </form>
 
-<form method="post" asp-page-handler="ExternalLogin" asp-route-provider="Google" asp-route-returnUrl="@Model.ReturnUrl">
-    <button type="submit">Sign in with Google</button>
-</form>
+<a href="/external/Google?returnUrl=@Model.ReturnUrl">Sign in with Google</a>
 
-<form method="post" asp-page-handler="ExternalLogin" asp-route-provider="Facebook" asp-route-returnUrl="@Model.ReturnUrl">
-    <button type="submit">Sign in with Facebook</button>
-</form>
+<a href="/external/Facebook?returnUrl=@Model.ReturnUrl">Sign in with Facebook</a>
 

--- a/api/Avancira.API/Pages/Account/Login.cshtml.cs
+++ b/api/Avancira.API/Pages/Account/Login.cshtml.cs
@@ -1,9 +1,7 @@
 using System.ComponentModel.DataAnnotations;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.AspNetCore.WebUtilities;
 using Avancira.Infrastructure.Identity.Users;
 
 namespace Avancira.API.Pages.Account;
@@ -48,11 +46,5 @@ public class LoginModel(SignInManager<User> signInManager) : PageModel
         return Page();
     }
 
-    public IActionResult OnPostExternalLogin(string provider, string? returnUrl = null)
-    {
-        var redirectUrl = QueryHelpers.AddQueryString(returnUrl ?? "/", "provider", provider);
-        var properties = _signInManager.ConfigureExternalAuthenticationProperties(provider, redirectUrl);
-        return Challenge(properties, provider);
-    }
 }
 


### PR DESCRIPTION
## Summary
- replace external login forms with links to `/external/{provider}`
- drop unused external login handler in Login page code-behind

## Testing
- ⚠️ `dotnet test` *(command not found: dotnet)*
- ⚠️ `apt-get update` *(403 errors fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b05d69fdb88327b162d9ea2395d954