### PR TITLE
Add external auth callback endpoint

### DIFF
--- a/api/Avancira.API/Controllers/ExternalAuthController.cs
+++ b/api/Avancira.API/Controllers/ExternalAuthController.cs
@@ -21,9 +21,16 @@ public class ExternalAuthController : BaseApiController
         }
 
         var normalized = parsed.ToString().ToLowerInvariant();
-        var callback = "/api/auth/external/callback";
+        var callback = "/api/auth/external-callback";
         var encodedCallback = Uri.EscapeDataString(callback);
         var url = $"{AuthConstants.Endpoints.Authorize}?{AuthConstants.Parameters.Provider}={normalized}&{AuthConstants.Parameters.RedirectUri}={encodedCallback}";
         return Redirect(url);
+    }
+
+    [HttpGet("external-callback")]
+    [AllowAnonymous]
+    public IActionResult ExternalCallback()
+    {
+        return Ok();
     }
 }


### PR DESCRIPTION
## Summary
- add external auth callback endpoint with temporary Ok response
- update external login redirect URI to new callback

## Testing
- `dotnet test Avancira.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b069f07e848327a84f662fd6a2ecef