### PR TITLE
Revoke session tokens and add tests

### DIFF
--- a/api/Avancira.API.Tests/AuthenticationServiceTests.cs
+++ b/api/Avancira.API.Tests/AuthenticationServiceTests.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using Moq;
 using Xunit;
+using OpenIddict.Abstractions;
 
 public class AuthenticationServiceTests
 {
@@ -48,7 +49,8 @@ public class AuthenticationServiceTests
         var pair2 = new TokenPair(CreateToken(userId, sid2), "refresh2", DateTime.UtcNow.AddHours(1));
         var tokenClient = new StubTokenEndpointClient(pair1, pair2);
 
-        var sessionService = new SessionService(dbContext);
+        var tokenManager = new Mock<IOpenIddictTokenManager>();
+        var sessionService = new SessionService(dbContext, tokenManager.Object);
         var validator = new TokenRequestParamsValidator();
         var jwtOptions = Options.Create(new JwtOptions { Key = JwtKey, Issuer = JwtIssuer, Audience = JwtAudience });
         var scopeOptions = Options.Create(new AuthScopeOptions { Scope = AuthConstants.Scopes.Api });

--- a/api/Avancira.API.Tests/SessionServiceTests.cs
+++ b/api/Avancira.API.Tests/SessionServiceTests.cs
@@ -7,6 +7,11 @@ using Avancira.Infrastructure.Persistence;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Moq;
+using OpenIddict.Abstractions;
+using System.Security.Claims;
+using Avancira.Domain.Identity;
+using Avancira.Infrastructure.Auth;
+using System.Collections.Generic;
 using Xunit;
 
 public class SessionServiceTests
@@ -33,7 +38,8 @@ public class SessionServiceTests
         Task RunAsync(Guid sid) => Task.Run(async () =>
         {
             await using var db = new AvanciraDbContext(options, new Mock<IPublisher>().Object);
-            var service = new SessionService(db);
+            var tokenManager = new Mock<IOpenIddictTokenManager>().Object;
+            var service = new SessionService(db, tokenManager);
             barrier.SignalAndWait();
             await service.StoreSessionAsync("user1", sid, clientInfo, DateTime.UtcNow.AddHours(1));
         });
@@ -46,5 +52,54 @@ public class SessionServiceTests
         (await assertionDb.Sessions.CountAsync()).Should().Be(1);
         var storedSessionId = (await assertionDb.Sessions.SingleAsync()).Id;
         storedSessionId.Should().BeOneOf(sid1, sid2);
+    }
+
+    [Fact]
+    public async Task RevokeSessionsAsync_RemovesTokensForSession()
+    {
+        var options = new DbContextOptionsBuilder<AvanciraDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var db = new AvanciraDbContext(options, new Mock<IPublisher>().Object);
+
+        var sessionId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        db.Sessions.Add(new Session(sessionId)
+        {
+            UserId = "user1",
+            Device = "device",
+            IpAddress = "127.0.0.1",
+            CreatedUtc = now,
+            AbsoluteExpiryUtc = now.AddHours(1),
+            LastRefreshUtc = now,
+            LastActivityUtc = now
+        });
+        await db.SaveChangesAsync();
+
+        var token = new object();
+        var tokenManager = new Mock<IOpenIddictTokenManager>();
+        tokenManager.Setup(m => m.FindBySubjectAsync("user1"))
+            .Returns(AsyncEnumerable(token));
+        tokenManager.Setup(m => m.GetTypeAsync(token))
+            .ReturnsAsync(OpenIddictConstants.TokenTypeHints.RefreshToken);
+        tokenManager.Setup(m => m.GetClaimsAsync(token))
+            .ReturnsAsync(new[] { new Claim(AuthConstants.Claims.SessionId, sessionId.ToString()) });
+
+        var service = new SessionService(db, tokenManager.Object);
+        await service.RevokeSessionsAsync("user1", new[] { sessionId });
+
+        tokenManager.Verify(m => m.TryRevokeAsync(token), Times.Once);
+    }
+
+    private static IAsyncEnumerable<object> AsyncEnumerable(params object[] tokens) => Get(tokens);
+
+    private static async IAsyncEnumerable<object> Get(IEnumerable<object> tokens)
+    {
+        foreach (var token in tokens)
+        {
+            yield return token;
+            await Task.Yield();
+        }
     }
 }

--- a/api/Avancira.Application/Identity/Tokens/RevokeSessionCommand.cs
+++ b/api/Avancira.Application/Identity/Tokens/RevokeSessionCommand.cs
@@ -16,7 +16,7 @@ public class RevokeSessionCommandHandler : IRequestHandler<RevokeSessionCommand>
 
     public async Task<Unit> Handle(RevokeSessionCommand request, CancellationToken cancellationToken)
     {
-        await _sessionService.RevokeSessionAsync(request.UserId, request.SessionId);
+        await _sessionService.RevokeSessionsAsync(request.UserId, new[] { request.SessionId });
         return Unit.Value;
     }
 


### PR DESCRIPTION
## Summary
- revoke OpenIddict refresh tokens when sessions are revoked
- ensure command uses batch revocation path
- add tests verifying session revocation removes associated tokens

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b07e71a97c83278f2f110f731d0958