### PR TITLE
chore: bump admin package versions

### DIFF
--- a/admin/Client/Directory.Packages.props
+++ b/admin/Client/Directory.Packages.props
@@ -11,12 +11,12 @@
   <ItemGroup>
     <PackageVersion Include="Mapster" Version="7.4.0" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.6.0.109712" />
-    <PackageVersion Include="MediatR" Version="12.4.1" />
+    <PackageVersion Include="MediatR" Version="12.5.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.3"  />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.3" PrivateAssets="all" />
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.6" />
     <PackageVersion Include="MudBlazor" Version="8.2.0" />
   </ItemGroup>
 </Project>

--- a/admin/Infrastructure/Directory.Packages.props
+++ b/admin/Infrastructure/Directory.Packages.props
@@ -15,12 +15,12 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.6.0.109712" />
-    <PackageVersion Include="MediatR" Version="12.4.1" />
+    <PackageVersion Include="MediatR" Version="12.5.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.3" PrivateAssets="all" />
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.6" />
     <PackageVersion Include="MudBlazor" Version="8.2.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- upgrade MediatR to 12.5.0 and Microsoft.Extensions.Http to 9.0.6 in admin projects

## Testing
- `dotnet restore admin/Client/Client.csproj` *(fails: dotnet not installed)*
- `dotnet restore admin/Infrastructure/Infrastructure.csproj` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b09bf5c63c83279f89cdbdaff1ff04