### PR TITLE
fix: cast session checkbox target to HTMLInputElement

### DIFF
--- a/Frontend.Angular/src/app/pages/sessions/sessions.component.html
+++ b/Frontend.Angular/src/app/pages/sessions/sessions.component.html
@@ -34,6 +34,6 @@
 <ng-template #selectCell let-item>
   <input type="checkbox"
          [checked]="selectedSessions.has(item.id)"
-         (change)="onSelectSession(item.id, $event.target.checked)">
+         (change)="onSelectSession(item.id, ($event.target as HTMLInputElement).checked)">
 </ng-template>
 


### PR DESCRIPTION
## Summary
- cast checkbox change event target to HTMLInputElement in sessions page

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f1ba7fc88327936ef5e2d8fe02bb