### PR TITLE
Remove redundant nav setting in carousel

### DIFF
--- a/Frontend.Angular/public/assets/js/script.js
+++ b/Frontend.Angular/public/assets/js/script.js
@@ -137,11 +137,10 @@ Version      : 1.0
 	if($('.owl-carousel.mentoring-course').length > 0 ){
 		var owl = $('.owl-carousel.mentoring-course');
 	      	owl.owlCarousel({
-	        margin: 24,
-	        nav : false,
-	        nav: true,
-	        loop: true,
-	        responsive: {
+                margin: 24,
+                nav: true,
+                loop: true,
+                responsive: {
 	          	0: {
 	            	items: 1
 	          	},


### PR DESCRIPTION
## Summary
- clean up mentoring course carousel config by removing duplicate `nav` entry

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: export not found and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f10e585c8327b964bbc6a8ebbfc9