### PR TITLE
fix: handle session selection with template ref

### DIFF
--- a/Frontend.Angular/src/app/pages/sessions/sessions.component.html
+++ b/Frontend.Angular/src/app/pages/sessions/sessions.component.html
@@ -33,7 +33,8 @@
 
 <ng-template #selectCell let-item>
   <input type="checkbox"
+         #cb
          [checked]="selectedSessions.has(item.id)"
-         (change)="onSelectSession(item.id, ($event.target as HTMLInputElement).checked)">
+         (change)="onSelectSession(item.id, cb.checked)">
 </ng-template>
 


### PR DESCRIPTION
## Summary
- use template reference variable on session checkbox to avoid unsafe change handler

## Testing
- `npm run build` (fails: Could not resolve "angular-oauth2-oidc"; Failed to inline external stylesheet)

------
https://chatgpt.com/codex/tasks/task_e_68b1f586bef08327909690f53f5ca26b