### PR TITLE
chore: remove deprecated usePkce

### DIFF
--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -30,7 +30,6 @@ export class AuthService {
       responseType: 'code',
       scope: 'api offline_access',
       redirectUri: environment.redirectUri,
-      usePkce: true,
     });
   }
 


### PR DESCRIPTION
## Summary
- remove deprecated `usePkce` option from OAuth configuration

## Testing
- `npm run build --prefix Frontend.Angular` *(fails: Could not resolve "angular-oauth2-oidc")*


------
https://chatgpt.com/codex/tasks/task_e_68b1f58a99bc8327a6351e778347e827