### PR TITLE
Use 'avancira-web' OAuth client ID across backend and Angular app

### DIFF
--- a/Frontend.Angular/src/app/environments/environment.prod.ts
+++ b/Frontend.Angular/src/app/environments/environment.prod.ts
@@ -4,7 +4,7 @@ export const environment = {
     frontendUrl: 'https://www.avancira.com',
     useSignalR: true,
     /** OAuth client identifier */
-    clientId: 'frontend',
+    clientId: 'avancira-web',
     /** Callback URL used after authentication */
     redirectUri: 'https://www.avancira.com/signin-callback',
   };

--- a/Frontend.Angular/src/app/environments/environment.staging.ts
+++ b/Frontend.Angular/src/app/environments/environment.staging.ts
@@ -4,7 +4,7 @@ export const environment = {
   frontendUrl: 'https://www.avancira.com',
   useSignalR: true,
   /** OAuth client identifier */
-  clientId: 'frontend',
+  clientId: 'avancira-web',
   /** Callback URL used after authentication */
   redirectUri: 'https://www.avancira.com/signin-callback',
 };

--- a/Frontend.Angular/src/app/environments/environment.ts
+++ b/Frontend.Angular/src/app/environments/environment.ts
@@ -4,7 +4,7 @@ export const environment = {
   frontendUrl: 'https://localhost:4200',
   useSignalR: true,
   /** OAuth client identifier */
-  clientId: 'frontend',
+  clientId: 'avancira-web',
   /** Callback URL used after authentication */
   redirectUri: 'https://localhost:4200/signin-callback',
 };


### PR DESCRIPTION
## Summary
- Set OpenIddict client identifier to `avancira-web`
- Align Angular environment `clientId` values with `avancira-web`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*
- `npm test -- --watch=false --browsers=ChromeHeadless --no-progress` *(fails: TypeScript and module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fcc286048327a3a488f9fa7c6995