### PR TITLE
Use frontend callback URL for OpenIddict app seeding

### DIFF
--- a/api/Avancira.Infrastructure/Persistence/IdentityDbInitializer.cs
+++ b/api/Avancira.Infrastructure/Persistence/IdentityDbInitializer.cs
@@ -17,6 +17,7 @@ internal sealed class IdentityDbInitializer(
     UserManager<User> userManager,
     TimeProvider timeProvider,
     IOptions<OriginOptions> originSettings,
+    IOptions<AppOptions> appOptions,
     IOpenIddictApplicationManager applicationManager) : IDbInitializer
 {
     public async Task SeedAsync(CancellationToken cancellationToken)
@@ -50,10 +51,8 @@ internal sealed class IdentityDbInitializer(
                 ClientSecret = "client-secret"
             };
 
-            if (originSettings.Value.OriginUrl is { } origin)
-            {
-                descriptor.RedirectUris.Add(origin);
-            }
+            var callbackUri = new Uri($"{appOptions.Value.FrontEndUrl.TrimEnd('/')}/auth/callback");
+            descriptor.RedirectUris.Add(callbackUri);
 
             descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Token);
 


### PR DESCRIPTION
## Summary
- Build OpenIddict redirect URI from frontend `/auth/callback`
- Inject `AppOptions` so redirect URI derives from configured FrontEndUrl

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b20a87e7e8832786d593a2bbee09eb