### PR TITLE
feat(auth): handle OAuth callback

### DIFF
--- a/Frontend.Angular/src/app/app.routes.ts
+++ b/Frontend.Angular/src/app/app.routes.ts
@@ -21,6 +21,7 @@ import { PrivacyComponent } from './pages/privacy/privacy.component';
 import { ProfileComponent } from './pages/profile/profile.component';
 import { SessionsComponent } from './pages/sessions/sessions.component';
 import { ResetPasswordComponent } from './pages/reset-password/reset-password.component';
+import { AuthCallbackComponent } from './pages/auth-callback/auth-callback.component';
 import { SigninComponent } from './pages/signin/signin.component';
 import { SignupComponent } from './pages/signup/signup.component';
 import { TabletestComponent } from './pages/tabletest/tabletest.component';
@@ -32,6 +33,7 @@ export const routes: Routes = [
   { path: 'video-call-window', component: VideoCallWindowComponent },
   { path: 'signup', component: SignupComponent },
   { path: 'signin', component: SigninComponent },
+  { path: 'auth/callback', component: AuthCallbackComponent },
   { path: 'forgot-password', component: ForgotPasswordComponent },
   { path: 'reset-password', component: ResetPasswordComponent },
   { path: 'confirm-email', component: ConfirmEmailComponent },

--- a/Frontend.Angular/src/app/environments/environment.prod.ts
+++ b/Frontend.Angular/src/app/environments/environment.prod.ts
@@ -6,5 +6,5 @@ export const environment = {
     /** OAuth client identifier */
     clientId: 'avancira-web',
     /** Callback URL used after authentication */
-    redirectUri: 'https://www.avancira.com/signin-callback',
+    redirectUri: 'http://localhost:4200/auth/callback',
   };

--- a/Frontend.Angular/src/app/environments/environment.staging.ts
+++ b/Frontend.Angular/src/app/environments/environment.staging.ts
@@ -6,5 +6,5 @@ export const environment = {
   /** OAuth client identifier */
   clientId: 'avancira-web',
   /** Callback URL used after authentication */
-  redirectUri: 'https://www.avancira.com/signin-callback',
+  redirectUri: 'http://localhost:4200/auth/callback',
 };

--- a/Frontend.Angular/src/app/environments/environment.ts
+++ b/Frontend.Angular/src/app/environments/environment.ts
@@ -6,5 +6,5 @@ export const environment = {
   /** OAuth client identifier */
   clientId: 'avancira-web',
   /** Callback URL used after authentication */
-  redirectUri: 'https://localhost:4200/signin-callback',
+  redirectUri: 'http://localhost:4200/auth/callback',
 };

--- a/Frontend.Angular/src/app/pages/auth-callback/auth-callback.component.spec.ts
+++ b/Frontend.Angular/src/app/pages/auth-callback/auth-callback.component.spec.ts
@@ -1,0 +1,38 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+
+import { AuthCallbackComponent } from './auth-callback.component';
+import { AuthService } from '../../services/auth.service';
+
+describe('AuthCallbackComponent', () => {
+  let fixture: ComponentFixture<AuthCallbackComponent>;
+  let auth: jasmine.SpyObj<AuthService>;
+  let router: jasmine.SpyObj<Router>;
+
+  beforeEach(async () => {
+    auth = jasmine.createSpyObj('AuthService', ['init']);
+    auth.init.and.returnValue(Promise.resolve());
+    router = jasmine.createSpyObj('Router', ['navigateByUrl']);
+
+    await TestBed.configureTestingModule({
+      imports: [AuthCallbackComponent],
+      providers: [
+        { provide: AuthService, useValue: auth },
+        { provide: Router, useValue: router },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { queryParamMap: convertToParamMap({ state: '/home' }) } },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AuthCallbackComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('initializes auth and navigates to sanitized return url', () => {
+    expect(auth.init).toHaveBeenCalled();
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/home');
+  });
+});

--- a/Frontend.Angular/src/app/pages/auth-callback/auth-callback.component.ts
+++ b/Frontend.Angular/src/app/pages/auth-callback/auth-callback.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-auth-callback',
+  template: ''
+})
+export class AuthCallbackComponent implements OnInit {
+  constructor(
+    private readonly auth: AuthService,
+    private readonly route: ActivatedRoute,
+    private readonly router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    this.auth.init().then(() => {
+      const url = this.route.snapshot.queryParamMap.get('state') ?? '/';
+      const isRelative = /^\/(?!\/)/.test(url) && !url.includes('://');
+      this.router.navigateByUrl(isRelative ? url : '/');
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- set OAuth redirect URI to `http://localhost:4200/auth/callback` in all environment configs
- add `AuthCallbackComponent` to initialize auth and redirect to stored return URL
- register `/auth/callback` route to avoid 404 after OAuth login

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: process did not complete; aborted)*
- `npm run build` *(fails: Cannot find module 'angular-oauth2-oidc' and font inlining errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b2107b5fe48327b78739e648ecfd54