### PR TITLE
Remove API scope from OpenIddict configuration

### DIFF
--- a/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
+++ b/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
@@ -28,7 +28,7 @@ public static class OpenIddictSetup
                        .AllowRefreshTokenFlow()
                        .RequireProofKeyForCodeExchange();
 
-                options.RegisterScopes("openid", "profile", "email", "offline_access", "api");
+                options.RegisterScopes("openid", "profile", "email", "offline_access");
 
                 // Replace with real certs in production
                 options.AddDevelopmentEncryptionCertificate()


### PR DESCRIPTION
## Summary
- remove unnecessary API scope from OpenIddict registration

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b35f2f78108327b1e9ee34bed0d389