### PR TITLE
Remove api scope from PKCE authorization request

### DIFF
--- a/admin/Infrastructure/Auth/Jwt/JwtAuthenticationService.cs
+++ b/admin/Infrastructure/Auth/Jwt/JwtAuthenticationService.cs
@@ -62,7 +62,7 @@ public sealed class JwtAuthenticationService : AuthenticationStateProvider, IAut
 
         var redirectUri = $"{_navigation.BaseUri}auth/callback";
         var authorizeUrl =
-            $"{_http.BaseAddress}connect/authorize?client_id=mobile&response_type=code&scope=api%20offline_access&redirect_uri={Uri.EscapeDataString(redirectUri)}&code_challenge={challenge}&code_challenge_method=S256&state={Uri.EscapeDataString(returnUrl)}";
+            $"{_http.BaseAddress}connect/authorize?client_id=mobile&response_type=code&scope=offline_access&redirect_uri={Uri.EscapeDataString(redirectUri)}&code_challenge={challenge}&code_challenge_method=S256&state={Uri.EscapeDataString(returnUrl)}";
 
         _navigation.NavigateTo(authorizeUrl, true);
     }


### PR DESCRIPTION
## Summary
- remove `api` scope from PKCE authorization request in the admin authentication service

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b35f4877bc83279d37f3d633361308