### PR TITLE
Expand OAuth scope for profile and offline access

### DIFF
--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -28,7 +28,7 @@ export class AuthService {
       issuer: environment.baseApiUrl,
       clientId: environment.clientId,
       responseType: 'code',
-      scope: 'offline_access',
+      scope: 'openid profile email offline_access',
       redirectUri: environment.redirectUri,
     });
   }


### PR DESCRIPTION
## Summary
- request additional profile, email, and offline access scopes for OAuth

## Testing
- `npm test -- --watch=false --progress=false --browsers=ChromeHeadless` *(fails: Cannot find module 'angular-oauth2-oidc' and other build errors)*
- `dotnet test` *(fails: command not found, apt repositories 403 during install attempt)*

------
https://chatgpt.com/codex/tasks/task_e_68b363c3cfc083278c94cbbd76c4e2a4