### PR TITLE
Add logout endpoint and configure post-logout redirect

### DIFF
--- a/Frontend.Angular/src/app/environments/environment.prod.ts
+++ b/Frontend.Angular/src/app/environments/environment.prod.ts
@@ -7,4 +7,6 @@ export const environment = {
     clientId: 'avancira-web',
     /** Callback URL used after authentication */
     redirectUri: 'http://localhost:4200/auth/callback',
+    /** URL to redirect to after logging out */
+    postLogoutRedirectUri: 'https://www.avancira.com',
   };

--- a/Frontend.Angular/src/app/environments/environment.staging.ts
+++ b/Frontend.Angular/src/app/environments/environment.staging.ts
@@ -7,4 +7,6 @@ export const environment = {
   clientId: 'avancira-web',
   /** Callback URL used after authentication */
   redirectUri: 'http://localhost:4200/auth/callback',
+  /** URL to redirect to after logging out */
+  postLogoutRedirectUri: 'https://www.avancira.com',
 };

--- a/Frontend.Angular/src/app/environments/environment.ts
+++ b/Frontend.Angular/src/app/environments/environment.ts
@@ -7,4 +7,6 @@ export const environment = {
   clientId: 'avancira-web',
   /** Callback URL used after authentication */
   redirectUri: 'https://localhost:4200/auth/callback',
+  /** URL to redirect to after logging out */
+  postLogoutRedirectUri: 'https://localhost:4200',
 };

--- a/Frontend.Angular/src/app/services/auth.service.spec.ts
+++ b/Frontend.Angular/src/app/services/auth.service.spec.ts
@@ -62,8 +62,10 @@ describe('AuthService', () => {
     expect(req.request.withCredentials).toBeTrue();
     req.flush(null);
 
-    expect(oauthSpy.logOut).toHaveBeenCalled();
-    expect(routerSpy.navigateByUrl).toHaveBeenCalled();
+    expect(oauthSpy.logOut).toHaveBeenCalledWith({
+      logoutUrl: `${environment.baseApiUrl}connect/logout`,
+      postLogoutRedirectUri: environment.postLogoutRedirectUri,
+    });
   });
 
   it('performs a single refresh for concurrent calls', fakeAsync(() => {

--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -30,6 +30,7 @@ export class AuthService {
       responseType: 'code',
       scope: 'openid profile email offline_access',
       redirectUri: environment.redirectUri,
+      postLogoutRedirectUri: environment.postLogoutRedirectUri,
     });
   }
 
@@ -81,7 +82,7 @@ export class AuthService {
     this.oauth.initCodeFlow(returnUrl);
   }
 
-  logout(navigate = true): void {
+  logout(): void {
     const sessionId = this.decode()?.sessionId;
     const revoke$ = sessionId
       ? this.sessionService.revokeSession(sessionId)
@@ -90,10 +91,10 @@ export class AuthService {
     revoke$
       .pipe(
         finalize(() => {
-          this.oauth.logOut();
-          if (navigate) {
-            this.router.navigateByUrl(this.redirectToSignIn());
-          }
+          this.oauth.logOut({
+            logoutUrl: `${environment.baseApiUrl}connect/logout`,
+            postLogoutRedirectUri: environment.postLogoutRedirectUri,
+          });
         }),
       )
       .subscribe();

--- a/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
+++ b/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
@@ -22,6 +22,7 @@ public static class OpenIddictSetup
                 options.SetAuthorizationEndpointUris(AuthConstants.Endpoints.Authorize)
                        .SetTokenEndpointUris(AuthConstants.Endpoints.Token)
                        .SetRevocationEndpointUris(AuthConstants.Endpoints.Revocation)
+                       .SetLogoutEndpointUris("/connect/logout")
                        .SetIssuer(new Uri(configuration["Auth:Issuer"]!)); // e.g. https://api.avancira.com/
 
                 options.AllowAuthorizationCodeFlow()


### PR DESCRIPTION
## Summary
- expose `/connect/logout` in OpenIddict configuration
- configure Angular OAuth service with `postLogoutRedirectUri` and call logout via backend endpoint
- add corresponding environment settings and update tests

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Cannot resolve modules and stylesheet imports)*

------
https://chatgpt.com/codex/tasks/task_e_68b364e43df483279423ea2987681762