### PR TITLE
Simplify login flow to remove provider argument

### DIFF
--- a/Frontend.Angular/src/app/pages/signup/signup.component.spec.ts
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.spec.ts
@@ -54,7 +54,7 @@ describe('SignupComponent', () => {
 
     component.authenticate(SocialProvider.Google);
 
-    expect(authService.startLogin).toHaveBeenCalledWith('/home', SocialProvider.Google);
+    expect(authService.startLogin).toHaveBeenCalledWith('/home');
   });
 
   it('should initiate Facebook signup flow', async () => {
@@ -64,7 +64,7 @@ describe('SignupComponent', () => {
 
     component.authenticate(SocialProvider.Facebook);
 
-    expect(authService.startLogin).toHaveBeenCalledWith('/home', SocialProvider.Facebook);
+    expect(authService.startLogin).toHaveBeenCalledWith('/home');
   });
 
   it('should sanitize external returnUrl', async () => {

--- a/Frontend.Angular/src/app/pages/signup/signup.component.ts
+++ b/Frontend.Angular/src/app/pages/signup/signup.component.ts
@@ -161,8 +161,8 @@ export class SignupComponent implements OnInit, OnDestroy {
       });
   }
 
-  authenticate(provider: SocialProvider): void {
-    this.authService.startLogin(this.returnUrl, provider);
+  authenticate(_provider: SocialProvider): void {
+    this.authService.startLogin(this.returnUrl);
   }
 
   ngOnDestroy(): void {

--- a/Frontend.Angular/src/app/services/auth.service.ts
+++ b/Frontend.Angular/src/app/services/auth.service.ts
@@ -9,7 +9,6 @@ import { environment } from '../environments/environment';
 import { INCLUDE_CREDENTIALS, SKIP_AUTH } from '../interceptors/auth.interceptor';
 import { RegisterUserRequest } from '../models/register-user-request';
 import { RegisterUserResponseDto } from '../models/register-user-response';
-import { SocialProvider } from '../models/social-provider';
 import { UserProfile } from '../models/UserProfile';
 import { SessionService } from './session.service';
 
@@ -76,8 +75,7 @@ export class AuthService {
     return this.refresh$;
   }
 
-  startLogin(returnUrl = this.router.url, provider?: SocialProvider): void {
-    this.oauth.customQueryParams = provider ? { provider } : {};
+  startLogin(returnUrl = this.router.url): void {
     this.oauth.initCodeFlow(returnUrl);
   }
 


### PR DESCRIPTION
## Summary
- Remove social provider argument from AuthService.startLogin
- Adjust SignupComponent to invoke startLogin without provider
- Update tests to reflect provider-free login

## Testing
- `npm test -- --watch=false` *(fails: Cannot find module 'angular-oauth2-oidc')*

------
https://chatgpt.com/codex/tasks/task_e_68b364a64950832797864a8f08efb4ac