### PR TITLE
feat(api): add forgot password page

### DIFF
--- a/api/Avancira.API/Pages/Account/ForgotPassword.cshtml
+++ b/api/Avancira.API/Pages/Account/ForgotPassword.cshtml
@@ -1,0 +1,28 @@
+@page
+@model Avancira.API.Pages.Account.ForgotPasswordModel
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@{
+    ViewData["Title"] = "Forgot Password";
+}
+
+@if (!string.IsNullOrEmpty(Model.Message))
+{
+    <p>@Model.Message</p>
+}
+
+<form method="post">
+    @Html.AntiForgeryToken()
+    <div asp-validation-summary="ModelOnly"></div>
+    <div>
+        <label asp-for="Input.Email"></label>
+        <input asp-for="Input.Email" type="email" />
+        <span asp-validation-for="Input.Email"></span>
+    </div>
+    <button type="submit">Send password reset link</button>
+</form>
+
+<p><a asp-page="/Account/Login">Back to login</a></p>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/api/Avancira.API/Pages/Account/ForgotPassword.cshtml.cs
+++ b/api/Avancira.API/Pages/Account/ForgotPassword.cshtml.cs
@@ -1,0 +1,39 @@
+using System.Threading;
+using System.ComponentModel.DataAnnotations;
+using Avancira.Application.Identity.Users.Abstractions;
+using Avancira.Application.Identity.Users.Dtos;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Avancira.API.Pages.Account;
+
+[ValidateAntiForgeryToken]
+public class ForgotPasswordModel : PageModel
+{
+    private readonly IUserService _userService;
+    public ForgotPasswordModel(IUserService userService) => _userService = userService;
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public string? Message { get; set; }
+
+    public class InputModel
+    {
+        [Required, EmailAddress]
+        public string Email { get; set; } = string.Empty;
+    }
+
+    public void OnGet() { }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+            return Page();
+
+        var origin = Request.Headers["Origin"].ToString();
+        await _userService.ForgotPasswordAsync(new ForgotPasswordDto { Email = Input.Email }, origin, CancellationToken.None);
+        Message = "If an account with that email exists, a password reset link has been sent.";
+        return Page();
+    }
+}


### PR DESCRIPTION
## Summary
- implement forgot password endpoint Razor page
- invoke user service to send reset link using request origin
- add minimal UI with email form and login link

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bb9191ca0c8327b1a23121f0971062