### PR TITLE
Add reset password Razor page

### DIFF
--- a/api/Avancira.API/Pages/Account/ResetPassword.cshtml
+++ b/api/Avancira.API/Pages/Account/ResetPassword.cshtml
@@ -1,0 +1,30 @@
+@page
+@model Avancira.API.Pages.Account.ResetPasswordModel
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@{
+    ViewData["Title"] = "Reset Password";
+}
+
+<form method="post">
+    @Html.AntiForgeryToken()
+    <div asp-validation-summary="ModelOnly"></div>
+    <input type="hidden" asp-for="Input.UserId" />
+    <input type="hidden" asp-for="Input.Token" />
+    <div>
+        <label asp-for="Input.Password"></label>
+        <input asp-for="Input.Password" type="password" />
+        <span asp-validation-for="Input.Password"></span>
+    </div>
+    <div>
+        <label asp-for="Input.ConfirmPassword"></label>
+        <input asp-for="Input.ConfirmPassword" type="password" />
+        <span asp-validation-for="Input.ConfirmPassword"></span>
+    </div>
+    <button type="submit">Reset Password</button>
+</form>
+
+<p><a asp-page="/Account/Login">Back to login</a></p>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/api/Avancira.API/Pages/Account/ResetPassword.cshtml.cs
+++ b/api/Avancira.API/Pages/Account/ResetPassword.cshtml.cs
@@ -1,0 +1,66 @@
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Linq;
+using Avancira.Application.Identity.Users.Abstractions;
+using Avancira.Application.Identity.Users.Dtos;
+using Avancira.Domain.Common.Exceptions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Avancira.API.Pages.Account;
+
+[ValidateAntiForgeryToken]
+public class ResetPasswordModel : PageModel
+{
+    private readonly IUserService _userService;
+    public ResetPasswordModel(IUserService userService) => _userService = userService;
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public class InputModel
+    {
+        public string UserId { get; set; } = string.Empty;
+        public string Token { get; set; } = string.Empty;
+
+        [Required]
+        public string Password { get; set; } = string.Empty;
+
+        [Required, Compare(nameof(Password), ErrorMessage = "Passwords do not match.")]
+        public string ConfirmPassword { get; set; } = string.Empty;
+    }
+
+    public void OnGet(string? userId, string? token)
+    {
+        Input.UserId = userId ?? string.Empty;
+        Input.Token = token ?? string.Empty;
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+            return Page();
+
+        var dto = new ResetPasswordDto
+        {
+            UserId = Input.UserId,
+            Password = Input.Password,
+            ConfirmPassword = Input.ConfirmPassword,
+            Token = Input.Token
+        };
+
+        try
+        {
+            await _userService.ResetPasswordAsync(dto, CancellationToken.None);
+            TempData["SuccessMessage"] = "Password reset successfully.";
+            return RedirectToPage("/Account/Login");
+        }
+        catch (AvanciraException ex)
+        {
+            var errors = ex.ErrorMessages.Any() ? ex.ErrorMessages : new[] { ex.Message };
+            foreach (var error in errors)
+                ModelState.AddModelError(string.Empty, error);
+            return Page();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement reset password UI and page model
- call user service to reset password with confirmation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9377e3e08327bbe919776dd2470a