### PR TITLE
Add forgot password link on login page

### DIFF
--- a/api/Avancira.API/Pages/Account/Login.cshtml
+++ b/api/Avancira.API/Pages/Account/Login.cshtml
@@ -18,6 +18,7 @@
         <label asp-for="Input.Password"></label>
         <input asp-for="Input.Password" type="password" />
         <span asp-validation-for="Input.Password"></span>
+        <a href="/Account/ForgotPassword?returnUrl=@Model.ReturnUrl">Forgot your password?</a>
     </div>
     <button type="submit">Log in</button>
 </form>


### PR DESCRIPTION
## Summary
- add forgotten password link under login form

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9385130c8327b878edea5f1ed11e