### PR TITLE
Store hashed refresh tokens for sessions

### DIFF
--- a/api/Avancira.API.Tests/SessionServiceTests.cs
+++ b/api/Avancira.API.Tests/SessionServiceTests.cs
@@ -41,7 +41,7 @@ public class SessionServiceTests
             var tokenManager = new Mock<IOpenIddictTokenManager>().Object;
             var service = new SessionService(db, tokenManager);
             barrier.SignalAndWait();
-            await service.StoreSessionAsync("user1", sid, clientInfo, DateTime.UtcNow.AddHours(1));
+            await service.StoreSessionAsync("user1", sid, "hash", clientInfo, DateTime.UtcNow.AddHours(1));
         });
 
         var t1 = RunAsync(sid1);

--- a/api/Avancira.Application/Identity/Tokens/ISessionService.cs
+++ b/api/Avancira.Application/Identity/Tokens/ISessionService.cs
@@ -11,7 +11,7 @@ public interface ISessionService
     Task<List<SessionDto>> GetActiveSessionsAsync(string userId);
     Task RevokeSessionAsync(string userId, Guid sessionId);
     Task RevokeSessionsAsync(string userId, IEnumerable<Guid> sessionIds);
-    Task<bool> ValidateSessionAsync(string userId, Guid sessionId);
-    Task StoreSessionAsync(string userId, Guid sessionId, ClientInfo clientInfo, DateTime refreshExpiry);
-    Task UpdateSessionAsync(string userId, Guid sessionId, DateTime newExpiry);
+    Task<bool> ValidateSessionAsync(string userId, Guid sessionId, string? refreshTokenHash = null);
+    Task StoreSessionAsync(string userId, Guid sessionId, string refreshTokenHash, ClientInfo clientInfo, DateTime refreshExpiry);
+    Task UpdateSessionAsync(string userId, Guid sessionId, string refreshTokenHash, DateTime newExpiry);
 }

--- a/api/Avancira.Domain/Identity/Session.cs
+++ b/api/Avancira.Domain/Identity/Session.cs
@@ -26,4 +26,5 @@ public class Session : BaseEntity<Guid>, IAggregateRoot
     public DateTime LastRefreshUtc { get; set; }
     public DateTime LastActivityUtc { get; set; }
     public DateTime? RevokedUtc { get; set; }
+    public string? RefreshTokenHash { get; set; }
 }

--- a/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
+++ b/api/Avancira.Infrastructure/Identity/OpenIddictSetup.cs
@@ -56,6 +56,10 @@ public static class OpenIddictSetup
                     builder.UseScopedHandler<SessionIdClaimsHandler>());
                 options.AddEventHandler<ApplyTokenResponseContext>(builder =>
                     builder.UseScopedHandler<RefreshTokenCookieHandler>());
+                options.AddEventHandler<ValidateTokenRequestContext>(builder =>
+                    builder.UseScopedHandler<RefreshTokenHashValidator>().SetOrder(int.MaxValue));
+                options.AddEventHandler<ApplyTokenResponseContext>(builder =>
+                    builder.UseScopedHandler<RefreshTokenHashStore>());
                 //options.AddEventHandler<ProcessAuthenticationContext>(builder =>
                 //    builder.UseScopedHandler<RefreshTokenFromCookieHandler>());
             })

--- a/api/Avancira.Infrastructure/Identity/RefreshTokenHashHandlers.cs
+++ b/api/Avancira.Infrastructure/Identity/RefreshTokenHashHandlers.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using Avancira.Application.Common;
+using Avancira.Application.Identity.Tokens;
+using Avancira.Infrastructure.Auth;
+using OpenIddict.Abstractions;
+using OpenIddict.Server;
+using static OpenIddict.Server.OpenIddictServerEvents;
+
+namespace Avancira.Infrastructure.Identity;
+
+internal static class RefreshTokenHash
+{
+    public static string ComputeHash(string token)
+    {
+        using var sha = SHA256.Create();
+        var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(token));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+}
+
+public sealed class RefreshTokenHashValidator : IOpenIddictServerHandler<ValidateTokenRequestContext>
+{
+    private readonly ISessionService _sessionService;
+
+    public RefreshTokenHashValidator(ISessionService sessionService)
+        => _sessionService = sessionService;
+
+    public async ValueTask HandleAsync(ValidateTokenRequestContext context)
+    {
+        if (context.Request is null ||
+            context.Principal is null ||
+            context.Request.GrantType != OpenIddictConstants.GrantTypes.RefreshToken ||
+            string.IsNullOrEmpty(context.Request.RefreshToken))
+        {
+            return;
+        }
+
+        var userId = context.Principal.GetClaim(OpenIddictConstants.Claims.Subject);
+        var sessionIdClaim = context.Principal.GetClaim(AuthConstants.Claims.SessionId);
+
+        if (string.IsNullOrEmpty(userId) ||
+            string.IsNullOrEmpty(sessionIdClaim) ||
+            !Guid.TryParse(sessionIdClaim, out var sessionId))
+        {
+            context.Reject(OpenIddictConstants.Errors.InvalidGrant, "The refresh token is no longer valid.");
+            return;
+        }
+
+        var hash = RefreshTokenHash.ComputeHash(context.Request.RefreshToken);
+        if (!await _sessionService.ValidateSessionAsync(userId, sessionId, hash))
+        {
+            context.Reject(OpenIddictConstants.Errors.InvalidGrant, "The refresh token is no longer valid.");
+        }
+    }
+}
+
+public sealed class RefreshTokenHashStore : IOpenIddictServerHandler<ApplyTokenResponseContext>
+{
+    private readonly ISessionService _sessionService;
+    private readonly IClientInfoService _clientInfoService;
+
+    public RefreshTokenHashStore(ISessionService sessionService, IClientInfoService clientInfoService)
+    {
+        _sessionService = sessionService;
+        _clientInfoService = clientInfoService;
+    }
+
+    public async ValueTask HandleAsync(ApplyTokenResponseContext context)
+    {
+        if (context.Principal is null || string.IsNullOrEmpty(context.Response?.RefreshToken))
+        {
+            return;
+        }
+
+        var userId = context.Principal.GetClaim(OpenIddictConstants.Claims.Subject);
+        var sessionIdClaim = context.Principal.GetClaim(AuthConstants.Claims.SessionId);
+        if (string.IsNullOrEmpty(userId) ||
+            string.IsNullOrEmpty(sessionIdClaim) ||
+            !Guid.TryParse(sessionIdClaim, out var sessionId))
+        {
+            return;
+        }
+
+        var hash = RefreshTokenHash.ComputeHash(context.Response.RefreshToken);
+        var refreshExpiry = DateTime.UtcNow.AddDays(7);
+
+        if (context.Request?.GrantType == OpenIddictConstants.GrantTypes.RefreshToken)
+        {
+            await _sessionService.UpdateSessionAsync(userId, sessionId, hash, refreshExpiry);
+        }
+        else
+        {
+            var clientInfo = await _clientInfoService.GetClientInfoAsync();
+            await _sessionService.StoreSessionAsync(userId, sessionId, hash, clientInfo, refreshExpiry);
+        }
+    }
+}

--- a/api/Avancira.Infrastructure/Persistence/Configurations/SessionConfiguration.cs
+++ b/api/Avancira.Infrastructure/Persistence/Configurations/SessionConfiguration.cs
@@ -17,6 +17,7 @@ public class SessionConfiguration : IEntityTypeConfiguration<Session>
         builder.Property(s => s.IpAddress).HasMaxLength(45);
         builder.Property(s => s.Country).HasMaxLength(100);
         builder.Property(s => s.City).HasMaxLength(100);
+        builder.Property(s => s.RefreshTokenHash).HasMaxLength(64);
         builder.HasIndex(s => s.Device);
         builder.HasIndex(s => s.UserAgent);
         builder.HasIndex(s => s.OperatingSystem);

--- a/api/Avancira.Migrations/Migrations/20250901000000_AddRefreshTokenHashToSessions.cs
+++ b/api/Avancira.Migrations/Migrations/20250901000000_AddRefreshTokenHashToSessions.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Avancira.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Avancira.Migrations.Migrations
+{
+    [DbContext(typeof(AvanciraDbContext))]
+    [Migration("20250901000000_AddRefreshTokenHashToSessions")]
+    public class AddRefreshTokenHashToSessions : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "RefreshTokenHash",
+                schema: "identity",
+                table: "Sessions",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RefreshTokenHash",
+                schema: "identity",
+                table: "Sessions");
+        }
+    }
+}

--- a/api/Avancira.Migrations/Migrations/AvanciraDbContextModelSnapshot.cs
+++ b/api/Avancira.Migrations/Migrations/AvanciraDbContextModelSnapshot.cs
@@ -245,6 +245,10 @@ namespace Avancira.Migrations.Migrations
                         .HasMaxLength(45)
                         .HasColumnType("character varying(45)");
 
+                    b.Property<string>("RefreshTokenHash")
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)");
+
                     b.Property<DateTime>("LastActivityUtc")
                         .HasColumnType("timestamp with time zone");
 


### PR DESCRIPTION
## Summary
- add RefreshTokenHash field to sessions
- hash refresh tokens when issued and validate hashes on refresh
- track refresh token hash updates in session service and migration

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test --prefix Frontend.Angular` *(hangs: no output beyond start)*

------
https://chatgpt.com/codex/tasks/task_e_68c025276ef48327bc5ec90889970818