### PR TITLE
Use config-based IdP URL for password reset links

### DIFF
--- a/api/Avancira.API/Controllers/UsersController.cs
+++ b/api/Avancira.API/Controllers/UsersController.cs
@@ -11,7 +11,6 @@ using Avancira.Application.Paging;
 using Avancira.Domain.Common.Exceptions;
 using Avancira.Application.Identity.Users.Abstractions;
 using Microsoft.AspNetCore.RateLimiting;
-using Microsoft.Extensions.Configuration;
 
 namespace Avancira.API.Controllers;
 
@@ -20,16 +19,13 @@ public class UsersController : BaseApiController
 {
     private readonly IAuditService _auditService;
     private readonly IUserService _userService;
-    private readonly IConfiguration _configuration;
 
     public UsersController(
         IAuditService auditService,
-        IUserService userService,
-        IConfiguration configuration)
+        IUserService userService)
     {
         _auditService = auditService;
         _userService = userService;
-        _configuration = configuration;
     }
 
     [HttpGet("{id:guid}")]
@@ -154,13 +150,7 @@ public class UsersController : BaseApiController
     [SwaggerOperation(OperationId = "ForgotPassword")]
     public async Task<IActionResult> ForgotPassword([FromBody] ForgotPasswordDto command, CancellationToken cancellationToken)
     {
-        var origin = Request.Headers["Origin"].ToString();
-        if (string.IsNullOrWhiteSpace(origin))
-        {
-            origin = _configuration["App:FrontendUrl"] ?? string.Empty;
-        }
-
-        await _userService.ForgotPasswordAsync(command, origin, cancellationToken);
+        await _userService.ForgotPasswordAsync(command, cancellationToken);
         return Ok("If an account with that email exists, a password reset link has been sent.");
     }
 

--- a/api/Avancira.API/Pages/Account/ForgotPassword.cshtml.cs
+++ b/api/Avancira.API/Pages/Account/ForgotPassword.cshtml.cs
@@ -31,8 +31,7 @@ public class ForgotPasswordModel : PageModel
         if (!ModelState.IsValid)
             return Page();
 
-        var origin = Request.Headers["Origin"].ToString();
-        await _userService.ForgotPasswordAsync(new ForgotPasswordDto { Email = Input.Email }, origin, CancellationToken.None);
+        await _userService.ForgotPasswordAsync(new ForgotPasswordDto { Email = Input.Email }, CancellationToken.None);
         Message = "If an account with that email exists, a password reset link has been sent.";
         return Page();
     }

--- a/api/Avancira.API/appsettings.Development.json
+++ b/api/Avancira.API/appsettings.Development.json
@@ -9,7 +9,8 @@
     "OriginUrl": "https://localhost:9000"
   },
   "App": {
-    "FrontendUrl": "https://localhost:4200"
+    "FrontendUrl": "https://localhost:4200",
+    "IdpUrl": "https://localhost:9000"
   },
   "Auth": {
     "Issuer": "https://localhost:9000/"

--- a/api/Avancira.API/appsettings.json
+++ b/api/Avancira.API/appsettings.json
@@ -7,7 +7,8 @@
     "OriginUrl": "https://www.avancira.com"
   },
   "App": {
-    "FrontendUrl": "https://www.avancira.com"
+    "FrontendUrl": "https://www.avancira.com",
+    "IdpUrl": "https://www.avancira.com"
   },
   "Auth": {
     "Issuer": "{Avancira__Auth__Issuer}"

--- a/api/Avancira.Application/Identity/Users/Abstractions/IUserService.cs
+++ b/api/Avancira.Application/Identity/Users/Abstractions/IUserService.cs
@@ -22,7 +22,7 @@ public interface IUserService
     Task<bool> HasPermissionAsync(string userId, string permission, CancellationToken cancellationToken = default);
 
     // passwords
-    Task ForgotPasswordAsync(ForgotPasswordDto request, string origin, CancellationToken cancellationToken);
+    Task ForgotPasswordAsync(ForgotPasswordDto request, CancellationToken cancellationToken);
     Task ResetPasswordAsync(ResetPasswordDto request, CancellationToken cancellationToken);
     Task<List<string>?> GetPermissionsAsync(string userId, CancellationToken cancellationToken);
 

--- a/api/Avancira.Infrastructure/Identity/Users/Services/IdentityLinkBuilder.cs
+++ b/api/Avancira.Infrastructure/Identity/Users/Services/IdentityLinkBuilder.cs
@@ -35,9 +35,10 @@ internal sealed class IdentityLinkBuilder
         return originUri.GetLeftPart(UriPartial.Path).TrimEnd('/');
     }
 
-    public string BuildResetPasswordLink(string origin, string userId, string encodedToken)
+    public string BuildResetPasswordLink(string userId, string encodedToken)
     {
-        var baseUri = origin.TrimEnd('/');
+        var baseUri = _config["App:IdpUrl"]?.TrimEnd('/')
+            ?? throw new AvanciraException("IdP URL missing");
         var endpoint = $"{baseUri}/reset-password";
         var withUserId = QueryHelpers.AddQueryString(endpoint, "userId", userId);
         var withToken = QueryHelpers.AddQueryString(withUserId, "token", encodedToken);

--- a/api/Avancira.Infrastructure/Identity/Users/Services/UserService.Password.cs
+++ b/api/Avancira.Infrastructure/Identity/Users/Services/UserService.Password.cs
@@ -10,7 +10,7 @@ namespace Avancira.Infrastructure.Identity.Users.Services;
 
 internal sealed partial class UserService
 {
-    public async Task ForgotPasswordAsync(ForgotPasswordDto request, string origin, CancellationToken cancellationToken)
+    public async Task ForgotPasswordAsync(ForgotPasswordDto request, CancellationToken cancellationToken)
     {
         var user = await userManager.FindByEmailAsync(request.Email);
 
@@ -20,12 +20,10 @@ internal sealed partial class UserService
             return;
         }
 
-        var sanitizedOrigin = linkBuilder.ValidateOrigin(origin, UserErrorMessages.PasswordResetUnavailable);
-
         var rawToken = await userManager.GeneratePasswordResetTokenAsync(user);
         var encodedToken = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(rawToken));
 
-        var resetPasswordUri = linkBuilder.BuildResetPasswordLink(sanitizedOrigin, user.Id, encodedToken);
+        var resetPasswordUri = linkBuilder.BuildResetPasswordLink(user.Id, encodedToken);
 
         var resetPasswordEvent = new ResetPasswordEvent
         {


### PR DESCRIPTION
## Summary
- build password reset links from `App:IdpUrl`
- drop origin parameter from forgot password flow
- add `App:IdpUrl` setting

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c04256bfc08327907927db399c1300