### PR TITLE
Remove session device tracking

### DIFF
--- a/api/Avancira.API.Tests/SessionServiceTests.cs
+++ b/api/Avancira.API.Tests/SessionServiceTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 public class SessionServiceTests
 {
     [Fact]
-    public async Task StoreSessionAsync_ConcurrentLogins_DoesNotCreateDuplicateSessions()
+    public async Task StoreSessionAsync_ConcurrentLogins_CreatesMultipleSessions()
     {
         var options = new DbContextOptionsBuilder<AvanciraDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -49,9 +49,7 @@ public class SessionServiceTests
         await Task.WhenAll(t1, t2);
 
         await using var assertionDb = new AvanciraDbContext(options, new Mock<IPublisher>().Object);
-        (await assertionDb.Sessions.CountAsync()).Should().Be(1);
-        var storedSessionId = (await assertionDb.Sessions.SingleAsync()).Id;
-        storedSessionId.Should().BeOneOf(sid1, sid2);
+        (await assertionDb.Sessions.CountAsync()).Should().Be(2);
     }
 
     [Fact]
@@ -68,7 +66,6 @@ public class SessionServiceTests
         db.Sessions.Add(new Session(sessionId)
         {
             UserId = "user1",
-            Device = "device",
             IpAddress = "127.0.0.1",
             CreatedUtc = now,
             AbsoluteExpiryUtc = now.AddHours(1),

--- a/api/Avancira.API.Tests/SessionsControllerTests.cs
+++ b/api/Avancira.API.Tests/SessionsControllerTests.cs
@@ -45,7 +45,6 @@ public class SessionsControllerTests
 
         var dto = new SessionDto(
             Guid.NewGuid(),
-            "device",
             null,
             null,
             "127.0.0.1",

--- a/api/Avancira.Application/Identity/Tokens/Dtos/SessionDto.cs
+++ b/api/Avancira.Application/Identity/Tokens/Dtos/SessionDto.cs
@@ -3,7 +3,6 @@ namespace Avancira.Application.Identity.Tokens.Dtos;
 public record SessionDto : IEquatable<SessionDto>
 {
     public Guid Id { get; init; }
-    public string Device { get; init; }
     public string? UserAgent { get; init; }
     public string? OperatingSystem { get; init; }
     public string IpAddress { get; init; }
@@ -18,7 +17,6 @@ public record SessionDto : IEquatable<SessionDto>
     // Add a constructor that matches the usage in SessionService
     public SessionDto(
         Guid id,
-        string device,
         string? userAgent,
         string? operatingSystem,
         string ipAddress,
@@ -31,7 +29,6 @@ public record SessionDto : IEquatable<SessionDto>
         DateTime? revokedUtc)
     {
         Id = id;
-        Device = device;
         UserAgent = userAgent;
         OperatingSystem = operatingSystem;
         IpAddress = ipAddress;

--- a/api/Avancira.Domain/Identity/Session.cs
+++ b/api/Avancira.Domain/Identity/Session.cs
@@ -15,7 +15,6 @@ public class Session : BaseEntity<Guid>, IAggregateRoot
     }
 
     public string UserId { get; set; } = default!;
-    public string Device { get; set; } = default!;
     public string? UserAgent { get; set; }
     public string? OperatingSystem { get; set; }
     public string IpAddress { get; set; } = default!;

--- a/api/Avancira.Infrastructure/Identity/Tokens/SessionService.cs
+++ b/api/Avancira.Infrastructure/Identity/Tokens/SessionService.cs
@@ -26,20 +26,10 @@ public class SessionService : ISessionService
 
     public async Task StoreSessionAsync(string userId, Guid sessionId, ClientInfo clientInfo, DateTime refreshExpiry)
     {
-        var existingSession = await _dbContext.Sessions
-            .SingleOrDefaultAsync(s => s.UserId == userId && s.Device == clientInfo.DeviceId);
-
-        if (existingSession != null)
-        {
-            _dbContext.Sessions.Remove(existingSession);
-            await _dbContext.SaveChangesAsync();
-        }
-
         var now = DateTime.UtcNow;
         var session = new Session(sessionId)
         {
             UserId = userId,
-            Device = clientInfo.DeviceId,
             UserAgent = clientInfo.UserAgent,
             OperatingSystem = clientInfo.OperatingSystem,
             IpAddress = clientInfo.IpAddress,
@@ -99,7 +89,6 @@ public class SessionService : ISessionService
             .Where(s => s.UserId == userId && s.RevokedUtc == null && s.AbsoluteExpiryUtc > DateTime.UtcNow)
             .Select(s => new SessionDto(
                 s.Id,
-                s.Device,
                 s.UserAgent,
                 s.OperatingSystem,
                 s.IpAddress,

--- a/api/Avancira.Infrastructure/Persistence/Configurations/SessionConfiguration.cs
+++ b/api/Avancira.Infrastructure/Persistence/Configurations/SessionConfiguration.cs
@@ -14,13 +14,12 @@ public class SessionConfiguration : IEntityTypeConfiguration<Session>
         builder.HasIndex(s => s.Id)
             .HasDatabaseName("IX_UserSessions_SessionId")
             .IsUnique();
-        builder.Property(s => s.Device).HasMaxLength(200);
         builder.Property(s => s.UserAgent).HasMaxLength(100);
         builder.Property(s => s.OperatingSystem).HasMaxLength(100);
         builder.Property(s => s.IpAddress).HasMaxLength(45);
         builder.Property(s => s.Country).HasMaxLength(100);
         builder.Property(s => s.City).HasMaxLength(100);
-        builder.HasIndex(s => s.Device);
+        builder.HasIndex(s => s.UserId);
         builder.HasIndex(s => s.UserAgent);
         builder.HasIndex(s => s.OperatingSystem);
         builder.HasIndex(s => s.IpAddress);
@@ -29,6 +28,5 @@ public class SessionConfiguration : IEntityTypeConfiguration<Session>
         builder.HasIndex(s => s.LastRefreshUtc);
         builder.HasIndex(s => s.LastActivityUtc);
         builder.HasIndex(s => s.RevokedUtc);
-        builder.HasIndex(s => new { s.UserId, s.Device }).IsUnique();
     }
 }

--- a/api/Avancira.Migrations/Migrations/20250903000000_RemoveDeviceFromSessions.cs
+++ b/api/Avancira.Migrations/Migrations/20250903000000_RemoveDeviceFromSessions.cs
@@ -1,0 +1,66 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Avancira.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Avancira.Migrations.Migrations
+{
+    [DbContext(typeof(AvanciraDbContext))]
+    [Migration("20250903000000_RemoveDeviceFromSessions")]
+    public class RemoveDeviceFromSessions : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Sessions_Device",
+                schema: "identity",
+                table: "Sessions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Sessions_UserId_Device",
+                schema: "identity",
+                table: "Sessions");
+
+            migrationBuilder.DropColumn(
+                name: "Device",
+                schema: "identity",
+                table: "Sessions");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sessions_UserId",
+                schema: "identity",
+                table: "Sessions",
+                column: "UserId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Sessions_UserId",
+                schema: "identity",
+                table: "Sessions");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Device",
+                schema: "identity",
+                table: "Sessions",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sessions_Device",
+                schema: "identity",
+                table: "Sessions",
+                column: "Device");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sessions_UserId_Device",
+                schema: "identity",
+                table: "Sessions",
+                columns: new[] { "UserId", "Device" },
+                unique: true);
+        }
+    }
+}

--- a/api/Avancira.Migrations/Migrations/AvanciraDbContextModelSnapshot.cs
+++ b/api/Avancira.Migrations/Migrations/AvanciraDbContextModelSnapshot.cs
@@ -235,11 +235,6 @@ namespace Avancira.Migrations.Migrations
                     b.Property<DateTime>("CreatedUtc")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<string>("Device")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
-
                     b.Property<string>("IpAddress")
                         .IsRequired()
                         .HasMaxLength(45)
@@ -276,8 +271,6 @@ namespace Avancira.Migrations.Migrations
 
                     b.HasIndex("CreatedUtc");
 
-                    b.HasIndex("Device");
-
                     b.HasIndex("IpAddress");
 
                     b.HasIndex("LastActivityUtc");
@@ -290,8 +283,7 @@ namespace Avancira.Migrations.Migrations
 
                     b.HasIndex("UserAgent");
 
-                    b.HasIndex("UserId", "Device")
-                        .IsUnique();
+                    b.HasIndex("UserId");
 
                     b.ToTable("Sessions", "identity");
                 });


### PR DESCRIPTION
## Summary
- drop Device property from Session aggregate and SessionDto
- update EF config and service logic accordingly
- add migration removing Device column and related indexes

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c04471a63c8327b0b416f9f616b420