### PR TITLE
Remove device ID cookie handling from client info

### DIFF
--- a/api/Avancira.API.Tests/SessionServiceTests.cs
+++ b/api/Avancira.API.Tests/SessionServiceTests.cs
@@ -25,7 +25,6 @@ public class SessionServiceTests
 
         var clientInfo = new ClientInfo
         {
-            DeviceId = "device1",
             IpAddress = "127.0.0.1",
             UserAgent = "agent",
             OperatingSystem = "os"

--- a/api/Avancira.Application/Common/ClientInfo.cs
+++ b/api/Avancira.Application/Common/ClientInfo.cs
@@ -2,7 +2,6 @@ namespace Avancira.Application.Common;
 
 public class ClientInfo
 {
-    public string DeviceId { get; set; } = default!;
     public string IpAddress { get; set; } = default!;
     public string UserAgent { get; set; } = default!;
     public string OperatingSystem { get; set; } = default!;

--- a/api/Avancira.Infrastructure/Identity/Tokens/SessionService.cs
+++ b/api/Avancira.Infrastructure/Identity/Tokens/SessionService.cs
@@ -27,7 +27,7 @@ public class SessionService : ISessionService
     public async Task StoreSessionAsync(string userId, Guid sessionId, ClientInfo clientInfo, DateTime refreshExpiry)
     {
         var existingSession = await _dbContext.Sessions
-            .SingleOrDefaultAsync(s => s.UserId == userId && s.Device == clientInfo.DeviceId);
+            .SingleOrDefaultAsync(s => s.UserId == userId);
 
         if (existingSession != null)
         {
@@ -39,7 +39,7 @@ public class SessionService : ISessionService
         var session = new Session(sessionId)
         {
             UserId = userId,
-            Device = clientInfo.DeviceId,
+            Device = clientInfo.UserAgent,
             UserAgent = clientInfo.UserAgent,
             OperatingSystem = clientInfo.OperatingSystem,
             IpAddress = clientInfo.IpAddress,


### PR DESCRIPTION
## Summary
- drop `DeviceId` from client info model
- simplify client info service to remove device-id cookie logic
- adjust session service to store sessions per user
- update unit tests

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0449a86ec8327867ec11010e084f6