### PR TITLE
Track refresh token IDs on user sessions

### DIFF
--- a/api/Avancira.Application/Identity/Tokens/ISessionService.cs
+++ b/api/Avancira.Application/Identity/Tokens/ISessionService.cs
@@ -12,5 +12,5 @@ public interface ISessionService
     Task RevokeSessionAsync(string userId, Guid sessionId);
     Task RevokeSessionsAsync(string userId, IEnumerable<Guid> sessionIds);
     Task<bool> ValidateSessionAsync(string userId, Guid sessionId);
-    Task StoreSessionAsync(string userId, Guid sessionId, ClientInfo clientInfo, DateTime refreshExpiry);
+    Task StoreSessionAsync(string userId, Guid sessionId, string refreshTokenId, ClientInfo clientInfo, DateTime refreshExpiry);
 }

--- a/api/Avancira.Domain/Identity/Session.cs
+++ b/api/Avancira.Domain/Identity/Session.cs
@@ -20,6 +20,7 @@ public class Session : BaseEntity<Guid>, IAggregateRoot
     public string IpAddress { get; set; } = default!;
     public string? Country { get; set; }
     public string? City { get; set; }
+    public string? ActiveRefreshTokenId { get; set; }
     public DateTime CreatedUtc { get; set; }
     public DateTime AbsoluteExpiryUtc { get; set; }
     public DateTime LastRefreshUtc { get; set; }

--- a/api/Avancira.Infrastructure/Persistence/Configurations/SessionConfiguration.cs
+++ b/api/Avancira.Infrastructure/Persistence/Configurations/SessionConfiguration.cs
@@ -19,7 +19,9 @@ public class SessionConfiguration : IEntityTypeConfiguration<Session>
         builder.Property(s => s.IpAddress).HasMaxLength(45);
         builder.Property(s => s.Country).HasMaxLength(100);
         builder.Property(s => s.City).HasMaxLength(100);
+        builder.Property(s => s.ActiveRefreshTokenId).HasMaxLength(100);
         builder.HasIndex(s => s.UserId);
+        builder.HasIndex(s => s.ActiveRefreshTokenId);
         builder.HasIndex(s => s.UserAgent);
         builder.HasIndex(s => s.OperatingSystem);
         builder.HasIndex(s => s.IpAddress);


### PR DESCRIPTION
## Summary
- Track refresh token ID for each session and map it in EF configuration
- Persist refresh token ID when storing sessions
- Use stored refresh token IDs to validate and revoke sessions

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c04c6145c48327aeffac934b54f1f4