### PR TITLE
feat: track session activity

### DIFF
--- a/api/Avancira.Application/Identity/Tokens/ISessionService.cs
+++ b/api/Avancira.Application/Identity/Tokens/ISessionService.cs
@@ -13,4 +13,6 @@ public interface ISessionService
     Task RevokeSessionsAsync(string userId, IEnumerable<Guid> sessionIds);
     Task<bool> ValidateSessionAsync(string userId, Guid sessionId);
     Task StoreSessionAsync(string userId, Guid sessionId, string refreshTokenId, ClientInfo clientInfo, DateTime refreshExpiry);
+    Task UpdateSessionActivityAsync(Guid sessionId, string refreshTokenId, DateTime refreshExpiry);
+    Task UpdateLastActivityAsync(Guid sessionId);
 }

--- a/api/Avancira.Infrastructure/Auth/Jwt/ConfigureJwtBearerOptions.cs
+++ b/api/Avancira.Infrastructure/Auth/Jwt/ConfigureJwtBearerOptions.cs
@@ -72,6 +72,8 @@ public class ConfigureJwtBearerOptions : IConfigureNamedOptions<JwtBearerOptions
                     return;
                 }
 
+                await sessionService.UpdateLastActivityAsync(sessionId);
+
                 if (context.Principal?.Identity != null)
                 {
                     Log.Debug("Token validated: " + context.Principal.Identity.Name);

--- a/api/Avancira.Infrastructure/Identity/IssueSessionHandler.cs
+++ b/api/Avancira.Infrastructure/Identity/IssueSessionHandler.cs
@@ -60,11 +60,7 @@ public sealed class IssueSessionHandler : IOpenIddictServerHandler<ApplyTokenRes
         }
         else
         {
-            session.ActiveRefreshTokenId = refreshTokenId;
-            session.LastActivityUtc = DateTime.UtcNow;
-            session.LastRefreshUtc = DateTime.UtcNow;
-            session.AbsoluteExpiryUtc = expiration.Value.UtcDateTime;
-            await dbContext.SaveChangesAsync();
+            await sessionService.UpdateSessionActivityAsync(sessionId, refreshTokenId, expiration.Value.UtcDateTime);
         }
     }
 }

--- a/api/Avancira.Infrastructure/Identity/Tokens/SessionService.cs
+++ b/api/Avancira.Infrastructure/Identity/Tokens/SessionService.cs
@@ -44,6 +44,34 @@ public class SessionService : ISessionService
         await _dbContext.SaveChangesAsync();
     }
 
+    public async Task UpdateSessionActivityAsync(Guid sessionId, string refreshTokenId, DateTime refreshExpiry)
+    {
+        var session = await _dbContext.Sessions.FindAsync(sessionId);
+        if (session is null)
+        {
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        session.ActiveRefreshTokenId = refreshTokenId;
+        session.LastRefreshUtc = now;
+        session.LastActivityUtc = now;
+        session.AbsoluteExpiryUtc = refreshExpiry;
+        await _dbContext.SaveChangesAsync();
+    }
+
+    public async Task UpdateLastActivityAsync(Guid sessionId)
+    {
+        var session = await _dbContext.Sessions.FindAsync(sessionId);
+        if (session is null)
+        {
+            return;
+        }
+
+        session.LastActivityUtc = DateTime.UtcNow;
+        await _dbContext.SaveChangesAsync();
+    }
+
     public async Task<bool> ValidateSessionAsync(string userId, Guid sessionId)
     {
         var session = await _dbContext.Sessions


### PR DESCRIPTION
## Summary
- add session activity update methods
- update session tracking handler on token rotation
- bump session last activity on access token use

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c072f22dd88327aef1a9dc9097593b