### PR TITLE
Add ActiveRefreshTokenId to sessions and drop obsolete device field

### DIFF
--- a/api/Avancira.Migrations/Migrations/20250904000000_RemoveDeviceAndAddActiveRefreshTokenIdToSessions.cs
+++ b/api/Avancira.Migrations/Migrations/20250904000000_RemoveDeviceAndAddActiveRefreshTokenIdToSessions.cs
@@ -6,8 +6,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 namespace Avancira.Migrations.Migrations
 {
     [DbContext(typeof(AvanciraDbContext))]
-    [Migration("20250903000000_RemoveDeviceFromSessions")]
-    public class RemoveDeviceFromSessions : Migration
+    [Migration("20250904000000_RemoveDeviceAndAddActiveRefreshTokenIdToSessions")]
+    public class RemoveDeviceAndAddActiveRefreshTokenIdToSessions : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
@@ -26,17 +26,41 @@ namespace Avancira.Migrations.Migrations
                 schema: "identity",
                 table: "Sessions");
 
+            migrationBuilder.AddColumn<string>(
+                name: "ActiveRefreshTokenId",
+                schema: "identity",
+                table: "Sessions",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
             migrationBuilder.CreateIndex(
                 name: "IX_Sessions_UserId",
                 schema: "identity",
                 table: "Sessions",
                 column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sessions_ActiveRefreshTokenId",
+                schema: "identity",
+                table: "Sessions",
+                column: "ActiveRefreshTokenId");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropIndex(
+                name: "IX_Sessions_ActiveRefreshTokenId",
+                schema: "identity",
+                table: "Sessions");
+
+            migrationBuilder.DropIndex(
                 name: "IX_Sessions_UserId",
+                schema: "identity",
+                table: "Sessions");
+
+            migrationBuilder.DropColumn(
+                name: "ActiveRefreshTokenId",
                 schema: "identity",
                 table: "Sessions");
 

--- a/api/Avancira.Migrations/Migrations/AvanciraDbContextModelSnapshot.cs
+++ b/api/Avancira.Migrations/Migrations/AvanciraDbContextModelSnapshot.cs
@@ -224,6 +224,10 @@ namespace Avancira.Migrations.Migrations
                     b.Property<DateTime>("AbsoluteExpiryUtc")
                         .HasColumnType("timestamp with time zone");
 
+                    b.Property<string>("ActiveRefreshTokenId")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
                     b.Property<string>("City")
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)");
@@ -267,6 +271,7 @@ namespace Avancira.Migrations.Migrations
                         .HasDatabaseName("IX_UserSessions_SessionId")
                         .IsUnique();
 
+                    b.HasIndex("ActiveRefreshTokenId");
                     b.HasIndex("AbsoluteExpiryUtc");
 
                     b.HasIndex("CreatedUtc");


### PR DESCRIPTION
## Summary
- replace legacy device-based session tracking with nullable `ActiveRefreshTokenId`
- update EF Core model snapshot to match schema

## Testing
- ⚠️ `dotnet ef database update --project api/Avancira.Migrations` *(command failed: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c0798008a48327a305ea663d5e3b55