### PR TITLE
refactor: remove environment dependency

### DIFF
--- a/api/Avancira.Infrastructure/Identity/RefreshTokenCookieHandler.cs
+++ b/api/Avancira.Infrastructure/Identity/RefreshTokenCookieHandler.cs
@@ -1,19 +1,12 @@
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Hosting;
 using OpenIddict.Server;
 using static OpenIddict.Server.OpenIddictServerEvents;
 using Avancira.Infrastructure.Auth;
-using Microsoft.AspNetCore;
 
 namespace Avancira.Infrastructure.Identity;
 
 public sealed class RefreshTokenCookieHandler : IOpenIddictServerHandler<ApplyTokenResponseContext>
 {
-    private readonly IHostEnvironment _environment;
-
-    public RefreshTokenCookieHandler(IHostEnvironment environment)
-        => _environment = environment;
-
     public ValueTask HandleAsync(ApplyTokenResponseContext context)
     {
         // Only add cookie if a refresh token was actually issued


### PR DESCRIPTION
## Summary
- remove unused IHostEnvironment dependency from refresh token cookie handler
- drop unnecessary using directives

## Testing
- `dotnet build Avancira.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bfbecebc8327ad754e27b0c5c438