### PR TITLE
Remove redundant default endpoint mapping

### DIFF
--- a/api/Avancira.API/Program.cs
+++ b/api/Avancira.API/Program.cs
@@ -55,8 +55,6 @@ public partial class Program {
 
         var app = builder.Build();
 
-        app.MapDefaultEndpoints();
-
         app.UseAvanciraFramework();
 
         app.UseHttpsRedirection();


### PR DESCRIPTION
## Summary
- rely on `UseAvanciraFramework` to map default endpoints by removing direct `app.MapDefaultEndpoints()` call in Program.cs

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bfd793908327a0e8c06ffb363559