### PR TITLE
Add password reset cooldown using in-memory cache

### DIFF
--- a/api/Avancira.API/Pages/Account/ForgotPassword.cshtml
+++ b/api/Avancira.API/Pages/Account/ForgotPassword.cshtml
@@ -18,11 +18,34 @@
         <input asp-for="Input.Email" type="email" />
         <span asp-validation-for="Input.Email"></span>
     </div>
-    <button type="submit">Send password reset link</button>
+    <div id="cooldown-message" style="display:@(Model.RemainingCooldown > 0 ? "block" : "none")">
+        Please wait <span id="cooldown-timer">@Model.RemainingCooldown</span> seconds before requesting another reset.
+    </div>
+    <button id="submitBtn" type="submit" @(Model.RemainingCooldown > 0 ? "disabled" : "")>Send password reset link</button>
 </form>
 
 <p><a asp-page="/Account/Login">Back to login</a></p>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
+    <script>
+        (function () {
+            var cooldown = @Model.RemainingCooldown;
+            if (cooldown > 0) {
+                var btn = document.getElementById('submitBtn');
+                var message = document.getElementById('cooldown-message');
+                var timer = document.getElementById('cooldown-timer');
+                btn.disabled = true;
+                var interval = setInterval(function () {
+                    cooldown--;
+                    if (timer) timer.textContent = cooldown;
+                    if (cooldown <= 0) {
+                        clearInterval(interval);
+                        if (message) message.style.display = 'none';
+                        if (btn) btn.disabled = false;
+                    }
+                }, 1000);
+            }
+        })();
+    </script>
 }

--- a/api/Avancira.API/Pages/Account/ForgotPassword.cshtml.cs
+++ b/api/Avancira.API/Pages/Account/ForgotPassword.cshtml.cs
@@ -1,9 +1,10 @@
-using System.Threading;
+using System;
 using System.ComponentModel.DataAnnotations;
 using Avancira.Application.Identity.Users.Abstractions;
 using Avancira.Application.Identity.Users.Dtos;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Avancira.API.Pages.Account;
 
@@ -11,12 +12,21 @@ namespace Avancira.API.Pages.Account;
 public class ForgotPasswordModel : PageModel
 {
     private readonly IUserService _userService;
-    public ForgotPasswordModel(IUserService userService) => _userService = userService;
+    private readonly IMemoryCache _cache;
+    private static readonly TimeSpan ResetCooldown = TimeSpan.FromSeconds(30);
+
+    public ForgotPasswordModel(IUserService userService, IMemoryCache cache)
+    {
+        _userService = userService;
+        _cache = cache;
+    }
 
     [BindProperty]
     public InputModel Input { get; set; } = new();
 
     public string? Message { get; set; }
+
+    public int RemainingCooldown { get; private set; }
 
     public class InputModel
     {
@@ -31,7 +41,24 @@ public class ForgotPasswordModel : PageModel
         if (!ModelState.IsValid)
             return Page();
 
-        await _userService.ForgotPasswordAsync(new ForgotPasswordDto { Email = Input.Email }, CancellationToken.None);
+        var ip = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        var cacheKey = $"pwreset:{Input.Email}:{ip}";
+        var now = DateTimeOffset.UtcNow;
+
+        if (_cache.TryGetValue(cacheKey, out DateTimeOffset lastRequest))
+        {
+            var elapsed = now - lastRequest;
+            if (elapsed < ResetCooldown)
+            {
+                RemainingCooldown = (int)Math.Ceiling((ResetCooldown - elapsed).TotalSeconds);
+                ModelState.AddModelError(string.Empty, $"Please wait {RemainingCooldown} seconds before requesting another password reset.");
+                return Page();
+            }
+        }
+
+        await _userService.ForgotPasswordAsync(new ForgotPasswordDto { Email = Input.Email }, HttpContext.RequestAborted);
+        _cache.Set(cacheKey, now, ResetCooldown);
+        RemainingCooldown = (int)ResetCooldown.TotalSeconds;
         Message = "If an account with that email exists, a password reset link has been sent.";
         return Page();
     }

--- a/api/Avancira.API/Program.cs
+++ b/api/Avancira.API/Program.cs
@@ -44,6 +44,7 @@ public partial class Program {
                 new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
         });
 
+        builder.Services.AddMemoryCache();
         builder.Services.AddRazorPages();
 
         using var authLoggerFactory = LoggerFactory.Create(logging => logging.AddConsole());


### PR DESCRIPTION
## Summary
- cache the last password reset request per email and IP
- enforce a 30 second cooldown before sending another reset email
- show a countdown and disable the form while in cooldown

## Testing
- `dotnet test api/Avancira.API.Tests/Avancira.API.Tests.csproj` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c3a8c6cc8327a7c7b231a5372b06