### PR TITLE
feat: align frontend session models with API

### DIFF
--- a/Frontend.Angular/src/app/models/device-sessions.ts
+++ b/Frontend.Angular/src/app/models/device-sessions.ts
@@ -1,0 +1,12 @@
+import { UserSession } from './session';
+
+export interface DeviceSessions {
+  deviceId: string;
+  deviceName?: string;
+  operatingSystem?: string;
+  userAgent?: string;
+  country?: string;
+  city?: string;
+  lastActivityUtc: string;
+  sessions: UserSession[];
+}

--- a/Frontend.Angular/src/app/models/session.ts
+++ b/Frontend.Angular/src/app/models/session.ts
@@ -1,14 +1,16 @@
-export interface Session {
+export interface UserSession {
   id: string;
-  device: string;
+  userId: string;
+  authorizationId: string;
+  deviceId: string;
+  deviceName?: string;
   userAgent?: string;
   operatingSystem?: string;
   ipAddress: string;
   country?: string;
   city?: string;
-  createdUtc: string;
-  lastActivityUtc: string;
-  lastRefreshUtc: string;
+  createdAtUtc: string;
   absoluteExpiryUtc: string;
-  revokedUtc?: string;
+  lastActivityUtc: string;
+  revokedAtUtc?: string;
 }

--- a/Frontend.Angular/src/app/services/session.service.spec.ts
+++ b/Frontend.Angular/src/app/services/session.service.spec.ts
@@ -1,19 +1,121 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { SessionService } from './session.service';
+import { environment } from '../environments/environment';
+import { DeviceSessions } from '../models/device-sessions';
+import { UserSession } from '../models/session';
 
 describe('SessionService', () => {
   let service: SessionService;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule]
     });
     service = TestBed.inject(SessionService);
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should fetch grouped sessions', () => {
+    const mockResponse: DeviceSessions[] = [
+      {
+        deviceId: 'device-1',
+        deviceName: 'Chrome on Mac',
+        operatingSystem: 'macOS',
+        userAgent: 'Chrome',
+        country: 'US',
+        city: 'NYC',
+        lastActivityUtc: '2024-01-01T00:00:00Z',
+        sessions: [
+          {
+            id: 'session-1',
+            userId: 'user-1',
+            authorizationId: 'auth-1',
+            deviceId: 'device-1',
+            deviceName: 'Chrome on Mac',
+            userAgent: 'Chrome',
+            operatingSystem: 'macOS',
+            ipAddress: '127.0.0.1',
+            country: 'US',
+            city: 'NYC',
+            createdAtUtc: '2024-01-01T00:00:00Z',
+            absoluteExpiryUtc: '2024-02-01T00:00:00Z',
+            lastActivityUtc: '2024-01-02T00:00:00Z',
+            revokedAtUtc: undefined
+          }
+        ]
+      }
+    ];
+
+    let result: DeviceSessions[] | undefined;
+    service.getSessions().subscribe(data => (result = data));
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/auth/sessions`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.withCredentials).toBeTrue();
+    req.flush(mockResponse);
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('should flatten grouped sessions', () => {
+    const mockDeviceSessions: DeviceSessions[] = [
+      {
+        deviceId: 'device-1',
+        deviceName: 'Chrome on Mac',
+        operatingSystem: 'macOS',
+        userAgent: 'Chrome',
+        country: 'US',
+        city: 'NYC',
+        lastActivityUtc: '2024-01-01T00:00:00Z',
+        sessions: [
+          {
+            id: 'session-1',
+            userId: 'user-1',
+            authorizationId: 'auth-1',
+            deviceId: 'device-1',
+            deviceName: undefined,
+            userAgent: undefined,
+            operatingSystem: undefined,
+            ipAddress: '127.0.0.1',
+            country: undefined,
+            city: undefined,
+            createdAtUtc: '2024-01-01T00:00:00Z',
+            absoluteExpiryUtc: '2024-02-01T00:00:00Z',
+            lastActivityUtc: '2024-01-02T00:00:00Z',
+            revokedAtUtc: undefined
+          }
+        ]
+      }
+    ];
+
+    const flattened = service.flattenSessions(mockDeviceSessions);
+
+    const expected: UserSession[] = [
+      {
+        id: 'session-1',
+        userId: 'user-1',
+        authorizationId: 'auth-1',
+        deviceId: 'device-1',
+        deviceName: 'Chrome on Mac',
+        userAgent: 'Chrome',
+        operatingSystem: 'macOS',
+        ipAddress: '127.0.0.1',
+        country: 'US',
+        city: 'NYC',
+        createdAtUtc: '2024-01-01T00:00:00Z',
+        absoluteExpiryUtc: '2024-02-01T00:00:00Z',
+        lastActivityUtc: '2024-01-02T00:00:00Z',
+        revokedAtUtc: undefined
+      }
+    ];
+
+    expect(flattened).toEqual(expected);
   });
 });

--- a/Frontend.Angular/src/app/services/session.service.ts
+++ b/Frontend.Angular/src/app/services/session.service.ts
@@ -1,10 +1,12 @@
 import { HttpClient, HttpContext } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 import { environment } from '../environments/environment';
 import { INCLUDE_CREDENTIALS, REQUIRES_AUTH } from '../interceptors/auth.interceptor';
-import { Session } from '../models/session';
+import { DeviceSessions } from '../models/device-sessions';
+import { UserSession } from '../models/session';
 
 @Injectable({ providedIn: 'root' })
 export class SessionService {
@@ -12,10 +14,43 @@ export class SessionService {
 
   constructor(private http: HttpClient) {}
 
-  getSessions(): Observable<Session[]> {
-    return this.http.get<Session[]>(`${this.api}/auth/sessions`, {
+  getSessions(): Observable<DeviceSessions[]> {
+    return this.http.get<DeviceSessions[]>(`${this.api}/auth/sessions`, {
       context: new HttpContext().set(REQUIRES_AUTH, true).set(INCLUDE_CREDENTIALS, true)
-    });
+    }).pipe(map(response => this.mapDeviceSessions(response)));
+  }
+
+  getFlatSessions(): Observable<UserSession[]> {
+    return this.getSessions().pipe(map(sessions => this.flattenSessions(sessions)));
+  }
+
+  flattenSessions(deviceSessions: DeviceSessions[]): UserSession[] {
+    return deviceSessions.flatMap(device =>
+      device.sessions.map(session => ({
+        ...session,
+        deviceId: device.deviceId || session.deviceId,
+        deviceName: session.deviceName ?? device.deviceName,
+        operatingSystem: session.operatingSystem ?? device.operatingSystem,
+        userAgent: session.userAgent ?? device.userAgent,
+        country: session.country ?? device.country,
+        city: session.city ?? device.city,
+      }))
+    );
+  }
+
+  private mapDeviceSessions(response: DeviceSessions[]): DeviceSessions[] {
+    return response.map(device => ({
+      ...device,
+      sessions: device.sessions.map(session => ({
+        ...session,
+        deviceId: session.deviceId || device.deviceId,
+        deviceName: session.deviceName ?? device.deviceName,
+        operatingSystem: session.operatingSystem ?? device.operatingSystem,
+        userAgent: session.userAgent ?? device.userAgent,
+        country: session.country ?? device.country,
+        city: session.city ?? device.city,
+      }))
+    }));
   }
 
   revokeSession(id: string): Observable<void> {


### PR DESCRIPTION
## Summary
- add DeviceSessions and UserSession interfaces to mirror the backend session DTOs
- update the session service to return grouped device sessions and provide flattening helpers
- refactor the sessions page to consume grouped sessions and refresh the table bindings
- extend the session service unit tests to cover the new data shapes and flattening logic

## Testing
- npm test -- --watch=false --browsers=ChromeHeadless *(fails: Angular CLI unavailable because npm install is blocked by registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d5aa6e3cd4832789408c27bfc56029