### PR TITLE
Refine account Razor pages to use shared layout

### DIFF
--- a/api/Avancira.API/Pages/Account/ForgotPassword.cshtml
+++ b/api/Avancira.API/Pages/Account/ForgotPassword.cshtml
@@ -3,28 +3,36 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @{
     ViewData["Title"] = "Forgot Password";
+    Layout = "../Shared/_AccountLayout";
 }
 
 @if (!string.IsNullOrEmpty(Model.Message))
 {
-    <p>@Model.Message</p>
+    <div class="account-form__alert">@Model.Message</div>
 }
 
-<form method="post">
+<form method="post" class="account-form">
     @Html.AntiForgeryToken()
-    <div asp-validation-summary="ModelOnly"></div>
-    <div>
-        <label asp-for="Input.Email"></label>
-        <input asp-for="Input.Email" type="email" />
-        <span asp-validation-for="Input.Email"></span>
+
+    <div asp-validation-summary="ModelOnly" class="account-form__validation"></div>
+
+    <div class="account-form__group">
+        <label asp-for="Input.Email" class="account-form__label"></label>
+        <input asp-for="Input.Email" type="email" class="account-form__input" autocomplete="email" />
+        <span asp-validation-for="Input.Email" class="account-form__error"></span>
     </div>
-    <div id="cooldown-message" style="display:@(Model.RemainingCooldown > 0 ? "block" : "none")">
+
+    <div id="cooldown-message" class="account-form__notice" style="display:@(Model.RemainingCooldown > 0 ? "block" : "none")">
         Please wait <span id="cooldown-timer">@Model.RemainingCooldown</span> seconds before requesting another reset.
     </div>
-    <button id="submitBtn" type="submit" @(Model.RemainingCooldown > 0 ? "disabled" : "")>Send password reset link</button>
+
+    <button id="submitBtn" type="submit" class="account-form__submit" @(Model.RemainingCooldown > 0 ? "disabled" : string.Empty)>Send password reset link</button>
 </form>
 
-<p><a asp-page="/Account/Login">Back to login</a></p>
+<p class="account-form__footer-text">
+    Remembered your password?
+    <a class="account-form__link" asp-page="/Account/Login">Back to login</a>
+</p>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
@@ -35,10 +43,10 @@
                 var btn = document.getElementById('submitBtn');
                 var message = document.getElementById('cooldown-message');
                 var timer = document.getElementById('cooldown-timer');
-                btn.disabled = true;
+                if (btn) btn.disabled = true;
                 var interval = setInterval(function () {
                     cooldown--;
-                    if (timer) timer.textContent = cooldown;
+                    if (timer) timer.textContent = Math.max(cooldown, 0);
                     if (cooldown <= 0) {
                         clearInterval(interval);
                         if (message) message.style.display = 'none';

--- a/api/Avancira.API/Pages/Account/Login.cshtml
+++ b/api/Avancira.API/Pages/Account/Login.cshtml
@@ -3,35 +3,70 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @{
     ViewData["Title"] = "Login";
+    Layout = "../Shared/_AccountLayout";
 }
 
-<form method="post">
+<form method="post" class="account-form">
     @Html.AntiForgeryToken()
     <input type="hidden" asp-for="ReturnUrl" />
 
-    <div>
-        <label asp-for="Input.Email"></label>
-        <input asp-for="Input.Email" type="email" />
-        <span asp-validation-for="Input.Email"></span>
+    <div asp-validation-summary="ModelOnly" class="account-form__validation"></div>
+
+    <div class="account-form__group">
+        <label asp-for="Input.Email" class="account-form__label"></label>
+        <input asp-for="Input.Email" type="email" class="account-form__input" autocomplete="email" />
+        <span asp-validation-for="Input.Email" class="account-form__error"></span>
     </div>
-    <div>
-        <label asp-for="Input.Password"></label>
-        <input asp-for="Input.Password" type="password" />
-        <span asp-validation-for="Input.Password"></span>
-        <a href="/Account/ForgotPassword?returnUrl=@Model.ReturnUrl">Forgot your password?</a>
-        <br />
-        <a href="/Account/Register?returnUrl=@Model.ReturnUrl">Register</a>
+
+    <div class="account-form__group">
+        <label asp-for="Input.Password" class="account-form__label"></label>
+        <input asp-for="Input.Password" type="password" class="account-form__input" autocomplete="current-password" />
+        <span asp-validation-for="Input.Password" class="account-form__error"></span>
     </div>
-    <button type="submit">Log in</button>
+
+    <div class="account-form__links">
+        <a class="account-form__link" href="/Account/ForgotPassword?returnUrl=@Model.ReturnUrl">Forgot your password?</a>
+        <a class="account-form__link" href="/Account/Register?returnUrl=@Model.ReturnUrl">Register</a>
+    </div>
+
+    <button type="submit" class="account-form__submit">Log in</button>
 </form>
 
-<hr />
+<div class="account-form__divider" role="separator">
+    <span>or continue with</span>
+</div>
 
-<!-- Preserve the returnUrl so the /connect/authorize flow resumes -->
-<a href="/api/auth/external-login?provider=Google&returnUrl=@Model.ReturnUrl">Sign in with Google</a>
-<br />
-<a href="/api/auth/external-login?provider=Facebook&returnUrl=@Model.ReturnUrl">Sign in with Facebook</a>
+<div class="social-login">
+    <button type="button"
+            class="social-login__button social-login__button--google"
+            data-provider="Google"
+            data-auth-endpoint="/api/auth/external-login"
+            data-return-url="@Model.ReturnUrl">
+        Sign in with Google
+    </button>
+    <button type="button"
+            class="social-login__button social-login__button--facebook"
+            data-provider="Facebook"
+            data-auth-endpoint="/api/auth/external-login"
+            data-return-url="@Model.ReturnUrl">
+        Sign in with Facebook
+    </button>
+</div>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
+    <script>
+        (function () {
+            const buttons = document.querySelectorAll('.social-login__button');
+            buttons.forEach(button => {
+                button.addEventListener('click', () => {
+                    const provider = button.dataset.provider;
+                    const endpoint = button.dataset.authEndpoint || '/api/auth/external-login';
+                    const returnUrl = button.dataset.returnUrl || '/';
+                    const url = `${endpoint}?provider=${encodeURIComponent(provider)}&returnUrl=${encodeURIComponent(returnUrl)}`;
+                    window.location.href = url;
+                });
+            });
+        })();
+    </script>
 }

--- a/api/Avancira.API/Pages/Account/Register.cshtml
+++ b/api/Avancira.API/Pages/Account/Register.cshtml
@@ -3,49 +3,66 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @{
     ViewData["Title"] = "Register";
+    Layout = "../Shared/_AccountLayout";
 }
 
-<form method="post">
+<form method="post" class="account-form">
     @Html.AntiForgeryToken()
     <input type="hidden" asp-for="ReturnUrl" />
 
-    <div>
-        <label asp-for="Input.FirstName"></label>
-        <input asp-for="Input.FirstName" />
-        <span asp-validation-for="Input.FirstName"></span>
+    <div asp-validation-summary="ModelOnly" class="account-form__validation"></div>
+
+    <div class="account-form__row">
+        <div class="account-form__group">
+            <label asp-for="Input.FirstName" class="account-form__label"></label>
+            <input asp-for="Input.FirstName" class="account-form__input" autocomplete="given-name" />
+            <span asp-validation-for="Input.FirstName" class="account-form__error"></span>
+        </div>
+        <div class="account-form__group">
+            <label asp-for="Input.LastName" class="account-form__label"></label>
+            <input asp-for="Input.LastName" class="account-form__input" autocomplete="family-name" />
+            <span asp-validation-for="Input.LastName" class="account-form__error"></span>
+        </div>
     </div>
-    <div>
-        <label asp-for="Input.LastName"></label>
-        <input asp-for="Input.LastName" />
-        <span asp-validation-for="Input.LastName"></span>
+
+    <div class="account-form__group">
+        <label asp-for="Input.UserName" class="account-form__label"></label>
+        <input asp-for="Input.UserName" class="account-form__input" autocomplete="username" />
+        <span asp-validation-for="Input.UserName" class="account-form__error"></span>
     </div>
-    <div>
-        <label asp-for="Input.UserName"></label>
-        <input asp-for="Input.UserName" />
-        <span asp-validation-for="Input.UserName"></span>
+
+    <div class="account-form__group">
+        <label asp-for="Input.Email" class="account-form__label"></label>
+        <input asp-for="Input.Email" type="email" class="account-form__input" autocomplete="email" />
+        <span asp-validation-for="Input.Email" class="account-form__error"></span>
     </div>
-    <div>
-        <label asp-for="Input.Email"></label>
-        <input asp-for="Input.Email" type="email" />
-        <span asp-validation-for="Input.Email"></span>
+
+    <div class="account-form__row">
+        <div class="account-form__group">
+            <label asp-for="Input.Password" class="account-form__label"></label>
+            <input asp-for="Input.Password" type="password" class="account-form__input" autocomplete="new-password" />
+            <span asp-validation-for="Input.Password" class="account-form__error"></span>
+        </div>
+        <div class="account-form__group">
+            <label asp-for="Input.ConfirmPassword" class="account-form__label"></label>
+            <input asp-for="Input.ConfirmPassword" type="password" class="account-form__input" autocomplete="new-password" />
+            <span asp-validation-for="Input.ConfirmPassword" class="account-form__error"></span>
+        </div>
     </div>
-    <div>
-        <label asp-for="Input.Password"></label>
-        <input asp-for="Input.Password" type="password" />
-        <span asp-validation-for="Input.Password"></span>
+
+    <div class="account-form__checkbox">
+        <input asp-for="Input.AcceptTerms" type="checkbox" class="account-form__checkbox-input" />
+        <label asp-for="Input.AcceptTerms" class="account-form__checkbox-label"></label>
+        <span asp-validation-for="Input.AcceptTerms" class="account-form__error"></span>
     </div>
-    <div>
-        <label asp-for="Input.ConfirmPassword"></label>
-        <input asp-for="Input.ConfirmPassword" type="password" />
-        <span asp-validation-for="Input.ConfirmPassword"></span>
-    </div>
-    <div>
-        <input asp-for="Input.AcceptTerms" type="checkbox" />
-        <label asp-for="Input.AcceptTerms"></label>
-        <span asp-validation-for="Input.AcceptTerms"></span>
-    </div>
-    <button type="submit">Register</button>
+
+    <button type="submit" class="account-form__submit">Register</button>
 </form>
+
+<p class="account-form__footer-text">
+    Already have an account?
+    <a class="account-form__link" href="/Account/Login?returnUrl=@Model.ReturnUrl">Log in</a>
+</p>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/api/Avancira.API/Pages/Account/ResetPassword.cshtml
+++ b/api/Avancira.API/Pages/Account/ResetPassword.cshtml
@@ -3,27 +3,34 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @{
     ViewData["Title"] = "Reset Password";
+    Layout = "../Shared/_AccountLayout";
 }
 
-<form method="post">
+<form method="post" class="account-form">
     @Html.AntiForgeryToken()
-    <div asp-validation-summary="ModelOnly"></div>
+    <div asp-validation-summary="ModelOnly" class="account-form__validation"></div>
     <input type="hidden" asp-for="Input.UserId" />
     <input type="hidden" asp-for="Input.Token" />
-    <div>
-        <label asp-for="Input.Password"></label>
-        <input asp-for="Input.Password" type="password" />
-        <span asp-validation-for="Input.Password"></span>
+
+    <div class="account-form__group">
+        <label asp-for="Input.Password" class="account-form__label"></label>
+        <input asp-for="Input.Password" type="password" class="account-form__input" autocomplete="new-password" />
+        <span asp-validation-for="Input.Password" class="account-form__error"></span>
     </div>
-    <div>
-        <label asp-for="Input.ConfirmPassword"></label>
-        <input asp-for="Input.ConfirmPassword" type="password" />
-        <span asp-validation-for="Input.ConfirmPassword"></span>
+
+    <div class="account-form__group">
+        <label asp-for="Input.ConfirmPassword" class="account-form__label"></label>
+        <input asp-for="Input.ConfirmPassword" type="password" class="account-form__input" autocomplete="new-password" />
+        <span asp-validation-for="Input.ConfirmPassword" class="account-form__error"></span>
     </div>
-    <button type="submit">Reset Password</button>
+
+    <button type="submit" class="account-form__submit">Reset Password</button>
 </form>
 
-<p><a asp-page="/Account/Login">Back to login</a></p>
+<p class="account-form__footer-text">
+    Remembered your password?
+    <a class="account-form__link" asp-page="/Account/Login">Back to login</a>
+</p>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/api/Avancira.API/Pages/Shared/_AccountLayout.cshtml
+++ b/api/Avancira.API/Pages/Shared/_AccountLayout.cshtml
@@ -1,0 +1,31 @@
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@{
+    Layout = null;
+    var pageTitle = ViewData["Title"] as string ?? "Account";
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>@pageTitle - Avancira</title>
+    <link rel="stylesheet" href="~/css/account.css" asp-append-version="true" />
+</head>
+<body class="account-layout">
+    <main class="account-layout__wrapper">
+        <section class="account-layout__card">
+            <header class="account-layout__header">
+                <a class="account-layout__brand" href="/" title="Back to Avancira home">
+                    <span class="account-layout__brand-mark">Avancira</span>
+                </a>
+                <h1 class="account-layout__title">@pageTitle</h1>
+            </header>
+            <div class="account-layout__body">
+                @RenderBody()
+            </div>
+        </section>
+    </main>
+
+    @RenderSection("Scripts", required: false)
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a shared _AccountLayout to render the branded account card and account stylesheet
- update login Razor page to rely on the layout, keep only the form content, and move social login logic into the Scripts section
- refactor register and password recovery Razor pages to adopt the shared card structure and consistent form classes

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d80dddc3388327afc24c521e09416c