### PR TITLE
Redirect unauthorized API calls to sign-in

### DIFF
--- a/Frontend.Angular/src/app/interceptors/auth.interceptor.ts
+++ b/Frontend.Angular/src/app/interceptors/auth.interceptor.ts
@@ -90,6 +90,7 @@ function handleAuthError(
 
   if (is401) {
     console.warn('⚠️ Unauthorized request - token invalid or expired', { url: req.url });
+    authService.handleUnauthorized();
   } else if (is403) {
     console.warn('⚠️ Forbidden request - insufficient permissions', { url: req.url });
   }


### PR DESCRIPTION
## Summary
- add a redirect guard in the Angular auth interceptor so 401 responses trigger the sign-in flow
- add an AuthService helper that clears local auth state and navigates to the sign-in route once per unauthorized event

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9840c328c8327a851ff88d2bbcfb4