### PR TITLE
feat: group sessions by device in dashboard

### DIFF
--- a/Frontend.Angular/src/app/layout/shared/sidebar/sidebar.component.html
+++ b/Frontend.Angular/src/app/layout/shared/sidebar/sidebar.component.html
@@ -57,6 +57,10 @@
                     <i class="fas fa-chalkboard-teacher"></i>Lessons <span><i class="fas fa-chevron-right"></i></span></a>
             </li>
             <li>
+                <a [routerLink]="'sessions'" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
+                    <i class="fas fa-sign-out-alt"></i>Sessions <span><i class="fas fa-chevron-right"></i></span></a>
+            </li>
+            <li>
                 <a [routerLink]="'listings'" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
                     <i class="fas fa-clipboard-list"></i>Listings <span><i class="fas fa-chevron-right"></i></span></a>
             </li>

--- a/Frontend.Angular/src/app/pages/sessions/sessions.component.html
+++ b/Frontend.Angular/src/app/pages/sessions/sessions.component.html
@@ -12,29 +12,77 @@
             </button>
           </div>
           <div class="card-body">
-            <p *ngIf="loading">Loading...</p>
-            <app-table *ngIf="!loading"
-              [data]="pagedSessions"
-              [columns]="sessionColumns"
-              [actions]="sessionActions"
-              [page]="page"
-              [pageSize]="pageSize"
-              [totalResults]="totalResults"
-              [pageSizeOptions]="pageSizeOptions"
-              (pageChange)="onPageChange($event)"
-              (pageSizeChange)="onPageSizeChange($event)">
-            </app-table>
+            <p *ngIf="loading" class="mb-0">Loading...</p>
+            <ng-container *ngIf="!loading">
+              <p *ngIf="deviceSessions.length === 0" class="text-muted mb-0">No active sessions.</p>
+              <div class="device-list" *ngIf="deviceSessions.length > 0">
+                <div class="device-card" *ngFor="let device of deviceSessions; trackBy: trackByDevice">
+                  <div class="device-card__header">
+                    <div class="device-card__details">
+                      <h6 class="device-card__title">{{ device.deviceName || device.deviceId }}</h6>
+                      <div class="device-card__meta">
+                        <span *ngIf="device.operatingSystem">{{ device.operatingSystem }}</span>
+                        <span *ngIf="device.userAgent">{{ device.userAgent }}</span>
+                        <span *ngIf="device.country || device.city">
+                          {{ device.city ? device.city + ', ' : '' }}{{ device.country || '' }}
+                        </span>
+                        <span>Last active: {{ formatDate(device.lastActivityUtc) }}</span>
+                      </div>
+                    </div>
+                    <div class="form-check">
+                      <input class="form-check-input" type="checkbox"
+                             [checked]="isDeviceFullySelected(device)"
+                             [indeterminate]="isDevicePartiallySelected(device)"
+                             (change)="toggleDeviceSelection(device, $event.target.checked)">
+                      <label class="form-check-label">Select all</label>
+                    </div>
+                  </div>
+                  <div class="table-responsive">
+                    <table class="table align-middle mb-0">
+                      <thead>
+                        <tr>
+                          <th scope="col" class="w-auto"></th>
+                          <th scope="col">IP Address</th>
+                          <th scope="col">Created</th>
+                          <th scope="col">Last Active</th>
+                          <th scope="col">Expires</th>
+                          <th scope="col" class="text-end">Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr *ngFor="let session of device.sessions; trackBy: trackBySession">
+                          <td>
+                            <input type="checkbox"
+                                   class="form-check-input"
+                                   [checked]="isSessionSelected(session.id)"
+                                   (change)="onSelectSession(session.id, $event.target.checked)">
+                          </td>
+                          <td>
+                            <div class="session-ip">{{ session.ipAddress }}</div>
+                            <div class="session-agent text-muted" *ngIf="session.userAgent && session.userAgent !== device.userAgent">
+                              {{ session.userAgent }}
+                            </div>
+                          </td>
+                          <td>{{ formatDate(session.createdAtUtc) }}</td>
+                          <td>{{ formatDate(session.lastActivityUtc) }}</td>
+                          <td>{{ formatDate(session.absoluteExpiryUtc) }}</td>
+                          <td class="text-end">
+                            <button class="btn btn-sm btn-outline-danger"
+                                    type="button"
+                                    (click)="revoke(session)">
+                              Revoke
+                            </button>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </ng-container>
           </div>
         </div>
       </div>
     </div>
   </div>
 </div>
-
-<ng-template #selectCell let-item>
-  <input type="checkbox"
-         #cb
-         [checked]="selectedSessions.has(item.id)"
-         (change)="onSelectSession(item.id, cb.checked)">
-</ng-template>
-

--- a/Frontend.Angular/src/app/pages/sessions/sessions.component.scss
+++ b/Frontend.Angular/src/app/pages/sessions/sessions.component.scss
@@ -1,2 +1,69 @@
 /* Styles for the sessions page */
 
+.device-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.device-card {
+  border: 1px solid #e3e3e3;
+  border-radius: 0.5rem;
+  padding: 1.25rem;
+  background-color: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.device-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.device-card__details {
+  flex: 1;
+  min-width: 0;
+}
+
+.device-card__title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.device-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.875rem;
+  color: #6c757d;
+}
+
+.session-ip {
+  font-weight: 500;
+}
+
+.session-agent {
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+  word-break: break-word;
+}
+
+@media (max-width: 767.98px) {
+  .device-card__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .device-card__meta {
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .table {
+    font-size: 0.875rem;
+  }
+}
+

--- a/Frontend.Angular/src/app/pages/sessions/sessions.component.ts
+++ b/Frontend.Angular/src/app/pages/sessions/sessions.component.ts
@@ -1,84 +1,33 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
-import { TableComponent } from '../../layout/shared/table/table.component';
 import { DeviceSessions } from '../../models/device-sessions';
 import { UserSession } from '../../models/session';
 import { SessionService } from '../../services/session.service';
 
 @Component({
   selector: 'app-sessions',
-  imports: [CommonModule, TableComponent],
+  imports: [CommonModule],
   templateUrl: './sessions.component.html',
   styleUrl: './sessions.component.scss'
 })
 export class SessionsComponent implements OnInit {
   deviceSessions: DeviceSessions[] = [];
-  sessions: UserSession[] = [];
-  pagedSessions: UserSession[] = [];
   loading = false;
 
-  page = 1;
-  pageSize = 10;
-  pageSizeOptions = [5, 10, 50, 100];
-  totalResults = 0;
-  @ViewChild('selectCell', { static: true }) selectCell!: TemplateRef<any>;
-
-  sessionColumns: any[] = [];
-
   selectedSessions = new Set<string>();
-
-  sessionActions = [
-    {
-      label: 'Revoke',
-      icon: 'fa-times',
-      class: 'btn-sm btn-outline-danger',
-      callback: (session: UserSession) => this.revoke(session)
-    }
-  ];
 
   constructor(private sessionService: SessionService) {}
 
   ngOnInit(): void {
-    this.sessionColumns = [
-      { key: 'select', label: '', cellTemplate: this.selectCell },
-      {
-        key: 'deviceName',
-        label: 'Device',
-        formatter: (value: any, item?: UserSession) => value || item?.deviceId || ''
-      },
-      { key: 'operatingSystem', label: 'OS' },
-      { key: 'userAgent', label: 'Agent' },
-      { key: 'ipAddress', label: 'IP Address' },
-      { key: 'country', label: 'Country' },
-      { key: 'city', label: 'City' },
-      {
-        key: 'createdAtUtc',
-        label: 'Created',
-        formatter: (value: any) => value ? new Date(value).toLocaleString() : ''
-      },
-      {
-        key: 'lastActivityUtc',
-        label: 'Last Active',
-        formatter: (value: any) => value ? new Date(value).toLocaleString() : ''
-      },
-      {
-        key: 'absoluteExpiryUtc',
-        label: 'Expires',
-        formatter: (value: any) => value ? new Date(value).toLocaleString() : ''
-      }
-    ];
     this.loadSessions();
   }
 
   loadSessions(): void {
     this.loading = true;
     this.sessionService.getSessions().subscribe({
-      next: s => {
-        this.deviceSessions = s;
-        this.sessions = this.sessionService.flattenSessions(s);
-        this.totalResults = this.sessions.length;
-        this.updatePagedSessions();
+      next: sessions => {
+        this.deviceSessions = sessions;
         this.selectedSessions.clear();
         this.loading = false;
       },
@@ -86,22 +35,6 @@ export class SessionsComponent implements OnInit {
         this.loading = false;
       }
     });
-  }
-
-  updatePagedSessions(): void {
-    const start = (this.page - 1) * this.pageSize;
-    this.pagedSessions = this.sessions.slice(start, start + this.pageSize);
-  }
-
-  onPageChange(newPage: number): void {
-    this.page = newPage;
-    this.updatePagedSessions();
-  }
-
-  onPageSizeChange(newSize: number): void {
-    this.pageSize = newSize;
-    this.page = 1;
-    this.updatePagedSessions();
   }
 
   onSelectSession(id: string, checked: boolean): void {
@@ -112,11 +45,35 @@ export class SessionsComponent implements OnInit {
     }
   }
 
+  isSessionSelected(id: string): boolean {
+    return this.selectedSessions.has(id);
+  }
+
+  isDeviceFullySelected(device: DeviceSessions): boolean {
+    return device.sessions.every(session => this.selectedSessions.has(session.id));
+  }
+
+  isDevicePartiallySelected(device: DeviceSessions): boolean {
+    const selectedCount = device.sessions.filter(session => this.selectedSessions.has(session.id)).length;
+    return selectedCount > 0 && selectedCount < device.sessions.length;
+  }
+
+  toggleDeviceSelection(device: DeviceSessions, checked: boolean): void {
+    device.sessions.forEach(session => {
+      if (checked) {
+        this.selectedSessions.add(session.id);
+      } else {
+        this.selectedSessions.delete(session.id);
+      }
+    });
+  }
+
   revokeSelected(): void {
     const ids = Array.from(this.selectedSessions);
     if (ids.length === 0) {
       return;
     }
+
     this.sessionService.revokeSessions(ids).subscribe({
       next: () => {
         this.selectedSessions.clear();
@@ -133,4 +90,12 @@ export class SessionsComponent implements OnInit {
       }
     });
   }
+
+  formatDate(value?: string | null): string {
+    return value ? new Date(value).toLocaleString() : '';
+  }
+
+  trackByDevice = (_index: number, device: DeviceSessions) => device.deviceId;
+
+  trackBySession = (_index: number, session: UserSession) => session.id;
 }

--- a/Frontend.Angular/src/app/services/session.service.ts
+++ b/Frontend.Angular/src/app/services/session.service.ts
@@ -1,12 +1,10 @@
 import { HttpClient, HttpContext } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 import { environment } from '../environments/environment';
 import { INCLUDE_CREDENTIALS, REQUIRES_AUTH } from '../interceptors/auth.interceptor';
 import { DeviceSessions } from '../models/device-sessions';
-import { UserSession } from '../models/session';
 
 @Injectable({ providedIn: 'root' })
 export class SessionService {
@@ -17,40 +15,7 @@ export class SessionService {
   getSessions(): Observable<DeviceSessions[]> {
     return this.http.get<DeviceSessions[]>(`${this.api}/auth/sessions`, {
       context: new HttpContext().set(REQUIRES_AUTH, true).set(INCLUDE_CREDENTIALS, true)
-    }).pipe(map(response => this.mapDeviceSessions(response)));
-  }
-
-  getFlatSessions(): Observable<UserSession[]> {
-    return this.getSessions().pipe(map(sessions => this.flattenSessions(sessions)));
-  }
-
-  flattenSessions(deviceSessions: DeviceSessions[]): UserSession[] {
-    return deviceSessions.flatMap(device =>
-      device.sessions.map(session => ({
-        ...session,
-        deviceId: device.deviceId || session.deviceId,
-        deviceName: session.deviceName ?? device.deviceName,
-        operatingSystem: session.operatingSystem ?? device.operatingSystem,
-        userAgent: session.userAgent ?? device.userAgent,
-        country: session.country ?? device.country,
-        city: session.city ?? device.city,
-      }))
-    );
-  }
-
-  private mapDeviceSessions(response: DeviceSessions[]): DeviceSessions[] {
-    return response.map(device => ({
-      ...device,
-      sessions: device.sessions.map(session => ({
-        ...session,
-        deviceId: session.deviceId || device.deviceId,
-        deviceName: session.deviceName ?? device.deviceName,
-        operatingSystem: session.operatingSystem ?? device.operatingSystem,
-        userAgent: session.userAgent ?? device.userAgent,
-        country: session.country ?? device.country,
-        city: session.city ?? device.city,
-      }))
-    }));
+    });
   }
 
   revokeSession(id: string): Observable<void> {


### PR DESCRIPTION
## Summary
- render grouped device sessions in the dashboard with bulk selection and revocation controls
- drop the frontend session-flattening logic now that the API returns grouped data
- add a Sessions entry to the dashboard sidebar and style the new layout

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dba012bee08327842937c768848a5c